### PR TITLE
Feat/modal base

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import JobPostCard from '@src/components/JobPostCard'
 import { ChevronDown, FolderIcon } from 'lucide-react'
 import './App.css'
 
+import TestModal from './components/modal/TestModal'
+
 function App() {
   const dropDownData = {
     dropdownTitle: '전체 카테고리',
@@ -41,6 +43,7 @@ function App() {
       <DropDown {...dropDownData} />
       <Card {...cardData} />
       <JobPostCard {...JobPostCardProps} />
+      <TestModal />
     </div>
   )
 }

--- a/src/components/modal/BaseModal.tsx
+++ b/src/components/modal/BaseModal.tsx
@@ -1,11 +1,12 @@
 import { useEffect, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
 // 모달 타입 정의
 type BaseModalProps = {
   open: boolean
   onClose: () => void
   children: ReactNode
-  maxWidth?: number | string
+  size?: 'vertical' | 'horizontal' // 'vertical' = 672px, 'horizontal' = 896px 피그마 참조
   dismissByOverlay?: boolean
 }
 
@@ -13,7 +14,7 @@ export default function BaseModal({
   open,
   onClose,
   children,
-  maxWidth = 640,
+  size = 'vertical',
   dismissByOverlay = true,
 }: BaseModalProps) {
   if (typeof document === 'undefined') return null
@@ -36,7 +37,27 @@ export default function BaseModal({
 
   if (!open) return null
 
-  return <>{/* 나중에 모달 내용 들어갈 자리 */}</>
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={(e) => {
+        if (!dismissByOverlay) return
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="absolute inset-0 bg-black/50" />
+      <div
+        className={`relative w-[92%] ${
+          size === 'horizontal' ? 'max-w-[896px]' : 'max-w-[672px]'
+        } rounded-[12px] bg-white p-6 shadow-2xl`}
+      >
+        {children}
+      </div>
+    </div>,
+    root
+  )
 }
 
 // 동적인 DOM 관리
@@ -60,6 +81,8 @@ function lockScroll() {
     if (gap) document.documentElement.style.paddingRight = `${gap}px`
   }
 }
+
+// 스크롤 방지 해지
 function unlockScroll() {
   _lockCount = Math.max(0, _lockCount - 1)
   if (_lockCount === 0) {

--- a/src/components/modal/BaseModal.tsx
+++ b/src/components/modal/BaseModal.tsx
@@ -51,7 +51,7 @@ export default function BaseModal({
       <div
         className={`relative w-[92%] ${
           size === 'horizontal' ? 'max-w-[896px]' : 'max-w-[672px]'
-        } rounded-[12px] bg-white p-6 shadow-2xl`}
+        } rounded-[12px] bg-white shadow-2xl`}
       >
         {children}
       </div>

--- a/src/components/modal/BaseModal.tsx
+++ b/src/components/modal/BaseModal.tsx
@@ -51,7 +51,7 @@ export default function BaseModal({
       <div
         className={`relative w-[92%] ${
           size === 'horizontal' ? 'max-w-[896px]' : 'max-w-[672px]'
-        } rounded-[12px] bg-white shadow-2xl`}
+        } min-h-[200px] min-w-[320px] rounded-[12px] bg-white shadow-2xl`}
       >
         {children}
       </div>

--- a/src/components/modal/BaseModal.tsx
+++ b/src/components/modal/BaseModal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, type ReactNode } from 'react'
+
+// 모달 타입 정의
+type BaseModalProps = {
+  open: boolean
+  onClose: () => void
+  children: ReactNode
+  maxWidth?: number | string
+  dismissByOverlay?: boolean
+}
+
+export default function BaseModal({
+  open,
+  onClose,
+  children,
+  maxWidth = 640,
+  dismissByOverlay = true,
+}: BaseModalProps) {
+  if (typeof document === 'undefined') return null
+  const root = getOrCreateRoot()
+
+  //   닫기
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose()
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  //   스크롤 방지
+  useEffect(() => {
+    if (!open) return
+    lockScroll()
+    return () => unlockScroll()
+  }, [open])
+
+  if (!open) return null
+
+  return <>{/* 나중에 모달 내용 들어갈 자리 */}</>
+}
+
+// 동적인 DOM 관리
+function getOrCreateRoot() {
+  let el = document.getElementById('modal-root')
+  if (!el) {
+    el = document.createElement('div')
+    el.id = 'modal-root'
+    document.body.appendChild(el)
+  }
+  return el
+}
+
+// 모달 open 했을때 스크롤 방지
+let _lockCount = 0 //모달 전용
+function lockScroll() {
+  _lockCount++
+  if (_lockCount === 1) {
+    const gap = window.innerWidth - document.documentElement.clientWidth
+    document.documentElement.style.overflow = 'hidden'
+    if (gap) document.documentElement.style.paddingRight = `${gap}px`
+  }
+}
+function unlockScroll() {
+  _lockCount = Math.max(0, _lockCount - 1)
+  if (_lockCount === 0) {
+    document.documentElement.style.overflow = ''
+    document.documentElement.style.paddingRight = ''
+  }
+}

--- a/src/components/modal/ModalFooter.tsx
+++ b/src/components/modal/ModalFooter.tsx
@@ -1,0 +1,13 @@
+type ModalFooterProps = {
+  left?: React.ReactNode // 안내문, 보조 텍스트 들어갈 공간
+  right?: React.ReactNode // 버튼 들어갈 공간
+}
+
+export default function ModalFooter({ left, right }: ModalFooterProps) {
+  return (
+    <footer className="mt-4 flex items-center justify-between gap-4 border-t border-gray-300 px-6 py-4">
+      <div className="text-sm text-gray-500">{left}</div>
+      <div className="flex items-center gap-2">{right}</div>
+    </footer>
+  )
+}

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -1,0 +1,40 @@
+import { X } from 'lucide-react'
+
+// 모달 헤더 props 타입 정의
+type ModalHeaderProps = {
+  title: React.ReactNode
+  subTitle?: React.ReactNode
+  onClose: () => void
+}
+
+export default function ModalHeader({
+  title,
+  subTitle,
+  onClose,
+}: ModalHeaderProps) {
+  const titleId = 'modal-title'
+  const subId = subTitle ? 'modal-sub' : undefined
+
+  return (
+    <header className="flex items-start justify-between gap-4 pb-4">
+      <div className="min-w-0">
+        <h2
+          id={titleId}
+          className="truncate text-xl font-semibold text-gray-900"
+        >
+          {title}
+        </h2>
+        {subTitle && (
+          <p id={subId} className="mt-1 text-sm text-gray-500">
+            {subTitle}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -16,7 +16,8 @@ export default function ModalHeader({
   const subId = subTitle ? 'modal-sub' : undefined
 
   return (
-    <header className="flex items-start justify-between gap-4 pb-4">
+    // items-center로할지 start로 할지 질문
+    <header className="flex w-full items-center justify-between gap-4 border-b border-gray-300 px-6 py-4">
       <div className="min-w-0">
         <h2
           id={titleId}
@@ -30,11 +31,9 @@ export default function ModalHeader({
           </p>
         )}
       </div>
-      <div className="flex items-center gap-2">
-        <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
-          <X className="h-5 w-5" />
-        </button>
-      </div>
+      <button onClick={onClose} className="text-gray-400 hover:text-gray-900">
+        <X className="h-5 w-5" />
+      </button>
     </header>
   )
 }

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -18,7 +18,7 @@ export default function ModalHeader({
   return (
     // items-center로할지 start로 할지 질문
     <header className="flex w-full items-center justify-between gap-4 border-b border-gray-300 px-6 py-4">
-      <div className="min-w-0">
+      <div className="flex min-w-0 flex-col items-start">
         <h2
           id={titleId}
           className="truncate text-xl font-semibold text-gray-900"

--- a/src/components/modal/TestModal.tsx
+++ b/src/components/modal/TestModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import BaseModal from './BaseModal'
+import ModalHeader from './ModalHeader'
 
 export default function TestModal() {
   const [open, setOpen] = useState(false)
@@ -15,8 +16,11 @@ export default function TestModal() {
 
       <BaseModal open={open} onClose={() => setOpen(false)}>
         <div className="text-center">
-          <h2 className="mb-4 text-xl font-bold">테스트 모달</h2>
-          <p className="mb-6 text-gray-300">모달 테스트</p>
+          <ModalHeader
+            title="지원 현황 관리"
+            subTitle="총 3명이 지원했습니다"
+            onClose={() => setOpen(false)}
+          />
           <button
             onClick={() => setOpen(false)}
             className="bg-danger-500 rounded px-4 py-2"

--- a/src/components/modal/TestModal.tsx
+++ b/src/components/modal/TestModal.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import BaseModal from './BaseModal'
+
+export default function TestModal() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="p-8 text-white">
+      <button
+        onClick={() => setOpen(true)}
+        className="bg-primary-500 rounded px-4 py-2"
+      >
+        모달 열기
+      </button>
+
+      <BaseModal open={open} onClose={() => setOpen(false)}>
+        <div className="text-center">
+          <h2 className="mb-4 text-xl font-bold">테스트 모달</h2>
+          <p className="mb-6 text-gray-300">모달 테스트</p>
+          <button
+            onClick={() => setOpen(false)}
+            className="bg-danger-500 rounded px-4 py-2"
+          >
+            닫기
+          </button>
+        </div>
+      </BaseModal>
+    </div>
+  )
+}

--- a/src/components/modal/TestModal.tsx
+++ b/src/components/modal/TestModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import BaseModal from './BaseModal'
 import ModalHeader from './ModalHeader'
+import ModalFooter from './ModalFooter'
 
 export default function TestModal() {
   const [open, setOpen] = useState(false)
@@ -21,12 +22,23 @@ export default function TestModal() {
             subTitle="총 3명이 지원했습니다"
             onClose={() => setOpen(false)}
           />
-          <button
-            onClick={() => setOpen(false)}
-            className="bg-danger-500 rounded px-4 py-2"
-          >
-            닫기
-          </button>
+          <div> 메인 내용이 들어갈 공간입니다.</div>
+          <ModalFooter
+            left={<span>* 표시된 항목은 필수 입력 사항입니다.</span>}
+            right={
+              <>
+                <button
+                  onClick={() => setOpen(false)}
+                  className="rounded bg-gray-200 px-3 py-2 text-gray-800"
+                >
+                  취소
+                </button>
+                <button className="bg-primary-500 rounded px-3 py-2 text-white">
+                  지원서 제출
+                </button>
+              </>
+            }
+          />
         </div>
       </BaseModal>
     </div>

--- a/src/components/modal/TestModal.tsx
+++ b/src/components/modal/TestModal.tsx
@@ -15,11 +15,11 @@ export default function TestModal() {
         모달 열기
       </button>
 
-      <BaseModal open={open} onClose={() => setOpen(false)}>
+      <BaseModal open={open} onClose={() => setOpen(false)} size="horizontal">
         <div className="text-center">
           <ModalHeader
             title="지원 현황 관리"
-            subTitle="총 3명이 지원했습니다"
+            subTitle="총 Node.js 백엔드 개발 스터디원 구합니다 - 총 3명이 지원했습니다."
             onClose={() => setOpen(false)}
           />
           <div> 메인 내용이 들어갈 공간입니다.</div>


### PR DESCRIPTION
## 📌 개요

 - 모달 공통 컴포넌트(BaseModal, ModalHeader, ModalFooter)를 구현했습니다.
 - 테스트용으로 TestModal에 적용하여 구조와 동작을 확인

## 🔧 작업 내용

- [x] BaseModal: Portal, ESC 닫기, 오버레이 닫기, 스크롤락 기능 추가
- [x] ModalHeader: 제목, 부제목, 닫기 버튼(X) 레이아웃 구현
- [x] ModalFooter: 좌측 안내문, 우측 버튼 슬롯 구조 구현
- [x] TestModal에 Header/Footer를 적용하여 UI와 동작 확인

## 📎 관련 이슈

- close #4 

## 📸 스크린샷 (선택)

<img width="364" height="218" alt="image" src="https://github.com/user-attachments/assets/38fe3b7e-73fa-4274-b603-8f9862f291d3" />

<img width="912" height="235" alt="image" src="https://github.com/user-attachments/assets/ef2b07d5-6173-4e26-acd9-021a52fe8ec9" /> 

가로형 모달 ( 헤더 : 타이틀, 서브타이틀 있는경우 / 풋터 : 텍스트, 버튼 모두 있을 경우)

<img width="693" height="224" alt="image" src="https://github.com/user-attachments/assets/6b6a54c4-1525-4720-ad8f-989405b7b19a" />

세로형 모달  (헤서 : 타이틀만 있는경우 / 풋터 없는 모달)

각각 모달의 

## 💬 리뷰어 참고 사항

 - BaseModal의 size prop(vertical / horizontal)을 사용하여 모달 폭을 제어
 - Header/Footer는 최소 레이아웃만 제공하고, 버튼/문구 등은 각 도메인 모달에서 처리하도록 설계
 - 필요시 최소 크기(min-width, min-height) 조정에 대한 논의 필요
