### PR TITLE
feat: application modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^0.515.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.62.0",
         "react-router": "^7.6.2",
         "react-router-dom": "7.6.2",
         "tailwindcss": "^4.1.10",
@@ -4796,6 +4797,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lucide-react": "^0.515.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.62.0",
     "react-router": "^7.6.2",
     "react-router-dom": "7.6.2",
     "tailwindcss": "^4.1.10",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,14 @@
 import { Route, Routes } from 'react-router'
 import './App.css'
 import HomePage from './pages'
+import TestModalPage from './pages/TestModalPage'
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
-
+      <Route path="/test-modal" element={<TestModalPage />} />
       <Route path="/courses" />
-
       {/* recruitment 라우트 */}
       <Route path="/recruitment" />
       <Route path=":id" />

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import Icon from '@components/Icon'
+import { Send } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 interface ButtonProps {
@@ -11,6 +12,7 @@ interface ButtonProps {
   bgColor?: string
   textColor?: string
   disabled?: boolean
+  onClick?: () => void
 }
 
 const Button = ({
@@ -23,6 +25,7 @@ const Button = ({
   bgColor = 'bg-primary-500',
   textColor = 'text-gray-700',
   disabled = false,
+  onClick,
 }: ButtonProps) => {
   // size별 텍스트 사이즈 매핑
   const textSizeStyles = {
@@ -56,6 +59,7 @@ const Button = ({
     <button
       type="button"
       disabled={disabled}
+      onClick={onClick}
       className={` ${buttonStyles.background} ${buttonStyles.text} ${buttonStyles.border} ${buttonStyles.borderWidth} ${buttonStyles.padding} ${buttonStyles.cursor} flex items-center gap-2 rounded-lg text-sm font-medium`}
     >
       {icon && (

--- a/src/components/modal/FormField.tsx
+++ b/src/components/modal/FormField.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react'
+
+type Props = {
+  label: string
+  required?: boolean
+  error?: string
+  children: ReactNode
+}
+
+export default function FormField({ label, required, error, children }: Props) {
+  return (
+    <div className="space-y-1">
+      <label className="block text-sm font-medium text-gray-900">
+        {label}
+        {required && <span className="text-danger-500 ml-1">*</span>}
+      </label>
+      {children}
+      {error && <p className="text-danger-500 text-xs">{error}</p>}
+    </div>
+  )
+}

--- a/src/components/modal/TextareaWithCounter.tsx
+++ b/src/components/modal/TextareaWithCounter.tsx
@@ -1,0 +1,24 @@
+import type { TextareaHTMLAttributes } from 'react'
+
+type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  maxLength: number
+  valueLength: number
+}
+export default function TextareaWithCounter({
+  maxLength,
+  valueLength,
+  ...rest
+}: Props) {
+  return (
+    <div className="space-y-1">
+      <textarea
+        className="focus:outline-primary-500 h-[122px] w-full resize-none rounded-lg border border-gray-500 px-3 py-2 placeholder:text-sm placeholder:text-gray-400 placeholder:italic disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+        maxLength={maxLength}
+        {...rest}
+      />
+      <div className="text-xs text-gray-500">
+        {valueLength}/{maxLength}
+      </div>
+    </div>
+  )
+}

--- a/src/components/recruitment/application/ApplicationModal.tsx
+++ b/src/components/recruitment/application/ApplicationModal.tsx
@@ -1,0 +1,167 @@
+import Button from '@src/components/Button'
+import BaseModal from '@src/components/modal/BaseModal'
+import FormField from '@src/components/modal/FormField'
+import ModalFooter from '@src/components/modal/ModalFooter'
+import ModalHeader from '@src/components/modal/ModalHeader'
+import TextareaWithCounter from '@src/components/modal/TextareaWithCounter'
+import { useForm } from 'react-hook-form'
+import { Send } from 'lucide-react'
+
+type Props = { open: boolean; onClose: () => void }
+
+type Form = {
+  intro: string
+  motive: string
+  goal: string
+  availability: string
+  hasExp: boolean
+  expDetail?: string
+}
+
+export default function ApplicationModal({ open, onClose }: Props) {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<Form>({ mode: 'onChange' })
+
+  const intro = watch('intro') ?? ''
+  const motive = watch('motive') ?? ''
+  const goal = watch('goal') ?? ''
+  const availability = watch('availability') ?? ''
+  const hasExp = watch('hasExp') ?? true
+  const expDetail = watch('expDetail') ?? ''
+
+  // 나중에 api 연결로 post 하기
+  const onSubmit = (data: Form) => {
+    console.log(data)
+    reset()
+    onClose()
+  }
+
+  // 닫을때 작성한거 리셋
+  // 경고 모달 제작해서 사용자한테 닫을 때
+  // 확인 다이얼로그 닫기/취소 시 작성 내용이 모두 사라집니다. 정말 닫으시겠습니까? 모달 붙일지 여부 결정.
+  const handleClose = () => {
+    reset()
+    onClose()
+  }
+
+  if (!open) return null
+
+  return (
+    <BaseModal open={open} onClose={onClose} size="vertical">
+      <div className="flex max-h-[80vh] flex-col">
+        <ModalHeader
+          title="스터디 지원서 작성"
+          subTitle="Unity 게임 개발 프로젝트 팀원 모집 입력"
+          // subTitle={title} 나중에 공고 제목 props 으로 내려 줘야함
+          onClose={handleClose}
+        />
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-10 py-4">
+          <FormField label="자기소개" required error={errors.intro?.message}>
+            <TextareaWithCounter
+              maxLength={500}
+              valueLength={intro.length}
+              {...register('intro', {
+                required: '자기소개를 입력해주세요.',
+                maxLength: 500,
+              })}
+              placeholder="본인에 대해 간략하게 소개해주세요. (학습, 배경, 관심분야, 현재 수중 등)"
+            />
+          </FormField>
+          <FormField label="지원동기" required error={errors.motive?.message}>
+            <TextareaWithCounter
+              maxLength={500}
+              valueLength={motive.length}
+              {...register('motive', {
+                required: '지원동기를 입력해 주세요.',
+                maxLength: 500,
+              })}
+              placeholder="이 스터디에 지원하게 된 동기를 작성해 주세요."
+            />
+          </FormField>
+          <FormField label="스터디목표" required error={errors.goal?.message}>
+            <TextareaWithCounter
+              maxLength={500}
+              valueLength={goal.length}
+              {...register('goal', {
+                required: '스터디 목표를 입력해 주세요.',
+                maxLength: 500,
+              })}
+              placeholder="이 스터디를 통해 달성하고 싶은 목표를 작성해주세요."
+            />
+          </FormField>
+          <FormField
+            label="가능한 시간대"
+            required
+            error={errors.availability?.message}
+          >
+            {/* 시간대는 maxLength 변경 해야 할듯 
+            높이도 줄여보는 방향으로, 아니면 시간 선택관련 컴포넌트를 따로 추가하는것도 좋아보이는데..... */}
+            <TextareaWithCounter
+              maxLength={500}
+              valueLength={availability.length}
+              {...register('availability', {
+                required: '가능한 시간을 입력해 주세요.',
+                maxLength: 500,
+              })}
+              placeholder="스터디 참여가 가능한 요일과 시간대를 작성해주세요(예: 평일 저녁 7~9시, 주말 오후)."
+            />
+          </FormField>
+          <FormField label="스터디 경험 유무">
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                {...register('hasExp')}
+                className="checked:bg-primary-500 h-3 w-3 appearance-none rounded-xs border border-gray-500 checked:border-1"
+              />
+              <span>스터디 참여 경험이 있습니다</span>
+            </label>
+          </FormField>
+          <FormField
+            label="구체적인 스터디 경험"
+            error={errors.expDetail?.message}
+          >
+            <TextareaWithCounter
+              maxLength={500}
+              valueLength={expDetail.length}
+              disabled={!hasExp}
+              {...register('expDetail', {
+                required: hasExp ? '경험이 있다면 상세히 입력해주세요.' : false,
+                maxLength: 500,
+              })}
+              placeholder="스터디 경험이 없으시면 비워두셔도 됩니다."
+            />
+          </FormField>
+        </div>
+      </div>
+
+      <ModalFooter
+        left="* 표시된 영역은 필수 입력 사항입니다."
+        right={
+          <>
+            <Button
+              buttonInnerText="취소"
+              variant="outline"
+              bgColor="text-gray-500"
+              textColor="text-gray-700"
+              borderColor="border-gray-300"
+              onClick={handleClose}
+            />
+            <Button
+              buttonInnerText="지원서 제출"
+              icon={Send}
+              bgColor="bg-primary-500"
+              borderColor="border-primary-500"
+              disabled={!isValid || isSubmitting}
+              onClick={handleSubmit(onSubmit)}
+            />
+          </>
+        }
+      />
+    </BaseModal>
+  )
+}

--- a/src/pages/TestModalPage.tsx
+++ b/src/pages/TestModalPage.tsx
@@ -1,0 +1,19 @@
+import ApplicationModal from '@src/components/recruitment/application/ApplicationModal'
+import { useState } from 'react'
+
+export default function TestModalPage() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="p-8">
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded bg-blue-500 px-4 py-2 text-white"
+      >
+        지원서 작성 모달 열기
+      </button>
+
+      <ApplicationModal open={open} onClose={() => setOpen(false)} />
+    </div>
+  )
+}


### PR DESCRIPTION
## 📌 개요

- 스터디 지원서 작성 모달 ApplicationModal 구현
- 공통 컴포넌트 FormField, TextareaWithCounter 제작 및 통합
- Button 컴포넌트 개선 onClick props 추가로 Footer 버튼 활용 가능하게 수정

## 🔧 작업 내용

- [x] Button 컴포넌트에 onClick props 추가
- [x] FormField 컴포넌트 구현 label, required, error 표시
- [x] TextareaWithCounter 컴포넌트 구현 maxLength, 현재 글자 수 표시
- [x] ApplicationModal 컴포넌트 구현
  - BaseModal + ModalHeader + ModalFooter 조합
  - react-hook-form 
  - 경험 유무 체크박스  true일 때만 구체적인 스터디 겸험 textarea 활성화
  - 제출 버튼에 Send 아이콘 추가
- [x] 테스트 페이지 및 라우터(/test)에서 동작 확인 가능

## 📎 관련 이슈

- close #15 

## 📸 스크린샷 (선택)
![공고지원모달](https://github.com/user-attachments/assets/34c87a3a-9658-4d76-91ce-2d0069b3a1f6)

## 💬 리뷰어 참고 사항

- 공통 컴포넌트 Button 컴포넌트에 hover 스타일 추가 필요
- 닫기/취소 시 "작성 내용이 삭제됩니다" 경고 다이얼로그 추가 예정
- 필수내용 미입력시 버튼 비활성화 보다는 활성화 시키고 적지 않는 곳으로 스크롤 이벤트가 어떨까 라는 개인적인 생각
