### PR TITLE
fix: 변경된 헤더 디렉토리 구조에 맞춰 import 형식 변경

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { Z_INDEX } from '@constants/ui'
 
-import Logo from '@components/Logo'
-import Navigation from '@components/Navigation'
+import Logo from '@components/Header/components/Logo'
+import Navigation from '@components/Header/components/Navigation'
 
 const Header = () => {
   return (

--- a/src/components/Header/components/Navigation.tsx
+++ b/src/components/Header/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import HeaderUserSection from '@components/HeaderUserSection'
+import HeaderUserSection from '@components/Header/components/HeaderUserSection'
 import { NAV_ITEMS } from '@src/constants/ui'
 import { Link } from 'react-router'
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import Header from '@components/Header'
+import Header from '@src/components/Header/Header'
 
 const HomePage = () => {
   return (


### PR DESCRIPTION
## 📌 개요
- 변경된 헤더 디렉토리 구조에 맞춰 import 형식 변경

## 🔧 작업 내용
- [x] 변경된 헤더 디렉토리 구조에 맞춰 import 형식 변경

## 📎 관련 이슈

- close #22  

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
|  <img  alt="스크린샷 2025-09-01 오전 10 14 06" src="https://github.com/user-attachments/assets/1b7ef0a5-0c66-4d7b-8d61-b63ff5f439cd" /> |<img alt="스크린샷 2025-09-01 오후 9 41 23" src="https://github.com/user-attachments/assets/74dfb4bf-0b90-4e14-8c01-92e3df927280" />
  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
