### PR TITLE
refactor: 버튼과 링크 props 와 디자인 일부 수정

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,4 @@
 import Icon from '@components/Icon'
-import { Send } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 interface ButtonProps {
@@ -15,7 +14,6 @@ interface ButtonProps {
   fontWeight?: 'normal' | 'medium' | 'semibold' | 'bold'
   iconSize?: 'sm' | 'md' | 'lg'
   onClick?: () => void
-
 }
 
 const Button = ({
@@ -26,7 +24,7 @@ const Button = ({
   variant = 'filled',
   borderColor = 'border-primary-500',
   bgColor = 'bg-primary-500',
-  textColor = 'text-gray-700',
+  textColor = 'text-primary-600',
   fontWeight = 'medium',
   disabled = false,
   iconSize = 'sm',

--- a/src/components/PageLink.tsx
+++ b/src/components/PageLink.tsx
@@ -12,7 +12,7 @@ interface PageLinkProps {
   hoverBgColor?: string
   hoverTextColor?: string
   fontWeight?: 'normal' | 'medium' | 'semibold' | 'bold'
-  linkTo: string
+  linkTo?: string
 }
 
 const PageLink = ({
@@ -22,7 +22,7 @@ const PageLink = ({
   variant = 'ghost',
   bgColor = 'bg-primary-500',
   borderColor = 'border-primary-500',
-  textColor = 'text-gray-700',
+  textColor = 'text-primary-600',
   hoverBgColor = 'hover:bg-primary-50',
   hoverTextColor = 'hover:text-primary-600',
   fontWeight = 'normal',
@@ -45,9 +45,6 @@ const PageLink = ({
     }
   }
 
-  const iconColor =
-    variant === 'filled' ? 'stroke-white' : textColor.replace('text', 'stroke')
-
   return (
     <Link
       to={`${linkTo}`}
@@ -57,7 +54,7 @@ const PageLink = ({
         <Icon
           icon={icon}
           size="sm"
-          className={`${iconColor} ${iconClassName}`}
+          className={`stroke-current ${iconClassName}`}
         />
       )}
       <span className={`${weightMap[fontWeight]} text-base`}>


### PR DESCRIPTION
## 📌 개요
- 버튼과 링크 props 와 디자인 일부 수정

## 🔧 작업 내용

- [x] 공통 컴포넌트인 버튼과 링크의 텍스트 컬러를 primary-600 로 수정
- [x] 공통 컴포넌트인 링크의 linkTo 를 옵셔널로 수정
- [x] 공통 컴포넌트인 버튼의 stroke 를 current 로 수정

## 📎 관련 이슈

- close #29 

## 📸 스크린샷 (선택)


## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
