### PR TITLE
feature: 공통 컴포넌트 드롭다운 기능 구현 #34

### DIFF
--- a/src/components/Chat/ChatHeader/ChatRoomHeader.tsx
+++ b/src/components/Chat/ChatHeader/ChatRoomHeader.tsx
@@ -8,7 +8,7 @@ interface ChatRoomHeaderProps {
   onClose: () => void
 }
 
-function ChatRoomHeader({
+export default function ChatRoomHeader({
   title,
   onlineCount,
   onBack,
@@ -49,4 +49,3 @@ function ChatRoomHeader({
     </div>
   )
 }
-export default ChatRoomHeader

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -15,7 +15,7 @@ interface DropDownProps {
   className?: string
 }
 
-function DropDown({
+export default function DropDown({
   selected,
   options = [],
   onSelect,
@@ -118,5 +118,3 @@ function DropDown({
     </div>
   )
 }
-
-export default DropDown

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -1,49 +1,121 @@
 import type { LucideIcon } from 'lucide-react'
+import { useState } from 'react'
 import Icon from './Icon'
 
 interface DropDownProps {
-  dropdownTitle: string
+  // 기존 props (하위 호환성 유지)
+  dropdownTitle?: string
+
+  // SelectableDropDown에서 가져온 새로운 props
+  selected?: string
+  options?: string[]
+  onSelect?: (value: string) => void
   leftIcon?: LucideIcon
   rightIcon?: LucideIcon
   leftIconClassName?: string
   rightIconClassName?: string
+  width?: string
+  disabled?: boolean
+  placeholder?: string
 }
 
 function DropDown({
   dropdownTitle,
+  selected,
+  options = [],
+  onSelect,
   leftIcon,
   rightIcon,
   leftIconClassName = '',
   rightIconClassName = '',
+  width = 'w-[378px]', // 기존 너비 유지하되 커스터마이징 가능
+  disabled = false,
+  placeholder = '선택하세요',
 }: DropDownProps) {
-  return (
-    <div className="relative flex h-[38px] w-[378px] items-center rounded-lg border border-gray-300">
-      {/* {leftIcon && (  <LeftIcon className="absolute top-0 left-0 flex h-full items-center justify-center pl-[12px]" />)} */}
-      {leftIcon && (
-        <div className="absolute top-1/2 left-3 -translate-y-1/2">
-          <Icon
-            icon={leftIcon}
-            size="sm" // ✅ 이제 작동함
-            className={`stroke-gray-400 ${leftIconClassName}`}
-          />
-        </div>
-      )}
+  const [isOpen, setIsOpen] = useState(false)
 
-      {/* <div className="flex w-full items-start justify-start rounded-[8px] border border-solid border-gray-300 bg-white py-[9px] pr-[33px] pl-[41px]"> */}
-      {/* <div className="flex justify-center text-[14px] leading-[0] font-normal text-nowrap text-black"> */}
-      <p className="pl-10 text-sm">{dropdownTitle}</p>
-      {/* </div> */}
-      {/* </div> */}
-      {rightIcon && (
-        <div className="absolute top-1/2 right-3 -translate-y-1/2">
-          <Icon
-            icon={rightIcon}
-            size="sm" // ✅ 이제 작동함
-            className={`stroke-gray-400 ${rightIconClassName}`}
+  // dropdownTitle이 있으면 기존 방식, 없으면 새로운 방식
+  const isStaticMode = dropdownTitle !== undefined
+  const displayText = isStaticMode ? dropdownTitle : selected || placeholder
+
+  const handleClick = () => {
+    if (disabled || isStaticMode) return
+    setIsOpen(!isOpen)
+  }
+
+  const handleSelect = (option: string) => {
+    onSelect?.(option)
+    setIsOpen(false)
+  }
+
+  return (
+    <div className="relative">
+      <div
+        className={`relative flex h-[38px] ${width} items-center rounded-lg border border-gray-300 bg-white transition-colors ${
+          !disabled && !isStaticMode ? 'cursor-pointer hover:bg-gray-50' : ''
+        } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        onClick={handleClick}
+      >
+        {leftIcon && (
+          <div className="absolute top-1/2 left-3 -translate-y-1/2">
+            <Icon
+              icon={leftIcon}
+              size="sm"
+              className={`stroke-gray-400 ${leftIconClassName}`}
+            />
+          </div>
+        )}
+
+        <p
+          className={`text-sm ${leftIcon ? 'pl-10' : 'pl-4'} ${
+            rightIcon ? 'pr-10' : 'pr-4'
+          } ${
+            !selected && !isStaticMode && !dropdownTitle ? 'text-gray-500' : ''
+          }`}
+        >
+          {displayText}
+        </p>
+
+        {rightIcon && (
+          <div className="absolute top-1/2 right-3 -translate-y-1/2">
+            <Icon
+              icon={rightIcon}
+              size="sm"
+              className={`stroke-gray-400 transition-transform ${rightIconClassName} ${
+                isOpen ? 'rotate-180' : ''
+              }`}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* 드롭다운 옵션 리스트 */}
+      {isOpen && !isStaticMode && options.length > 0 && (
+        <>
+          {/* 배경 오버레이 (클릭 시 닫기) */}
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setIsOpen(false)}
           />
-        </div>
+
+          {/* 옵션 리스트 */}
+          <div
+            className={`absolute top-full left-0 z-20 mt-1 ${width} rounded-lg border border-gray-200 bg-white shadow-lg`}
+          >
+            {options.map((option) => (
+              <button
+                key={option}
+                onClick={() => handleSelect(option)}
+                className={`w-full px-4 py-2 text-left text-sm transition-colors first:rounded-t-lg last:rounded-b-lg hover:bg-gray-50 ${
+                  option === selected ? 'bg-primary-50 text-primary-600' : ''
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </>
       )}
-      {/* <RightIcon className="absolute top-0 right-0 flex h-full items-center justify-start pr-[12px]" /> */}
     </div>
   )
 }

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -1,12 +1,8 @@
 import type { LucideIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Icon from './Icon'
 
 interface DropDownProps {
-  // 기존 props (하위 호환성 유지)
-  dropdownTitle?: string
-
-  // SelectableDropDown에서 가져온 새로운 props
   selected?: string
   options?: string[]
   onSelect?: (value: string) => void
@@ -20,7 +16,6 @@ interface DropDownProps {
 }
 
 function DropDown({
-  dropdownTitle,
   selected,
   options = [],
   onSelect,
@@ -28,18 +23,16 @@ function DropDown({
   rightIcon,
   leftIconClassName = '',
   rightIconClassName = '',
-  width = 'w-[378px]', // 기존 너비 유지하되 커스터마이징 가능
+  width = 'w-[378px]',
   disabled = false,
   placeholder = '선택하세요',
 }: DropDownProps) {
   const [isOpen, setIsOpen] = useState(false)
-
-  // dropdownTitle이 있으면 기존 방식, 없으면 새로운 방식
-  const isStaticMode = dropdownTitle !== undefined
-  const displayText = isStaticMode ? dropdownTitle : selected || placeholder
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const displayText = selected || placeholder
 
   const handleClick = () => {
-    if (disabled || isStaticMode) return
+    if (disabled) return
     setIsOpen(!isOpen)
   }
 
@@ -47,13 +40,27 @@ function DropDown({
     onSelect?.(option)
     setIsOpen(false)
   }
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        isOpen &&
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
 
   return (
-    <div className="relative">
+    <div className="relative" ref={dropdownRef}>
       <div
-        className={`relative flex h-[38px] ${width} items-center rounded-lg border border-gray-300 bg-white transition-colors ${
-          !disabled && !isStaticMode ? 'cursor-pointer hover:bg-gray-50' : ''
-        } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        className={`relative flex ${width} items-center rounded-lg border border-gray-300 py-[9px] ${
+          !disabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
+        }`}
         onClick={handleClick}
       >
         {leftIcon && (
@@ -69,9 +76,7 @@ function DropDown({
         <p
           className={`text-sm ${leftIcon ? 'pl-10' : 'pl-4'} ${
             rightIcon ? 'pr-10' : 'pr-4'
-          } ${
-            !selected && !isStaticMode && !dropdownTitle ? 'text-gray-500' : ''
-          }`}
+          } ${!selected ? 'text-gray-500' : ''}`}
         >
           {displayText}
         </p>
@@ -90,14 +95,8 @@ function DropDown({
       </div>
 
       {/* 드롭다운 옵션 리스트 */}
-      {isOpen && !isStaticMode && options.length > 0 && (
+      {isOpen && options.length > 0 && (
         <>
-          {/* 배경 오버레이 (클릭 시 닫기) */}
-          <div
-            className="fixed inset-0 z-10"
-            onClick={() => setIsOpen(false)}
-          />
-
           {/* 옵션 리스트 */}
           <div
             className={`absolute top-full left-0 z-20 mt-1 ${width} rounded-lg border border-gray-200 bg-white shadow-lg`}

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -10,9 +10,9 @@ interface DropDownProps {
   rightIcon?: LucideIcon
   leftIconClassName?: string
   rightIconClassName?: string
-  width?: string
   disabled?: boolean
   placeholder?: string
+  className?: string
 }
 
 function DropDown({
@@ -23,7 +23,7 @@ function DropDown({
   rightIcon,
   leftIconClassName = '',
   rightIconClassName = '',
-  width = 'w-[378px]',
+  className = '',
   disabled = false,
   placeholder = '선택하세요',
 }: DropDownProps) {
@@ -58,7 +58,7 @@ function DropDown({
   return (
     <div className="relative" ref={dropdownRef}>
       <div
-        className={`relative flex ${width} items-center rounded-lg border border-gray-300 py-[9px] ${
+        className={`relative flex ${className} items-center rounded-lg border border-gray-300 py-[9px] ${
           !disabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
         }`}
         onClick={handleClick}
@@ -99,7 +99,7 @@ function DropDown({
         <>
           {/* 옵션 리스트 */}
           <div
-            className={`absolute top-full left-0 z-20 mt-1 ${width} rounded-lg border border-gray-200 bg-white shadow-lg`}
+            className={`absolute top-full left-0 z-20 mt-1 ${className} rounded-lg border border-gray-200 bg-white shadow-lg`}
           >
             {options.map((option) => (
               <button

--- a/src/pages/TestPage/TestUIPage.tsx
+++ b/src/pages/TestPage/TestUIPage.tsx
@@ -10,8 +10,22 @@ import {
   UserRoundPlus,
   X,
 } from 'lucide-react'
+import { useState } from 'react'
 
 export default function TestUIPage() {
+  const [selectedCategory, setSelectedCategory] = useState('전체')
+  const [selectedSort, setSelectedSort] = useState('인기순')
+
+  // 임시 데이터 (나중에 상수로 분리)
+  const categories = [
+    '전체',
+    '프론트엔드',
+    'JavaScript',
+    'React',
+    '백엔드',
+    '클라우드',
+  ]
+  const sortOptions = ['인기순', '최신순', '가격낮은순', '평점높은순']
   return (
     <div className="space-y-4 p-4">
       {/* 드롭다운 */}
@@ -19,6 +33,34 @@ export default function TestUIPage() {
         dropdownTitle="전체 카테고리"
         leftIcon={FolderIcon}
         rightIcon={ChevronDown}
+      />
+      {/* 선택 가능한 드롭다운 */}
+      <DropDown
+        selected={selectedCategory}
+        options={categories}
+        onSelect={setSelectedCategory}
+        leftIcon={FolderIcon}
+        rightIcon={ChevronDown}
+        placeholder="카테고리 선택"
+        width="w-full"
+      />
+      {/* 정렬 드롭다운 */}
+      <DropDown
+        selected={selectedSort}
+        options={sortOptions}
+        onSelect={setSelectedSort}
+        rightIcon={ChevronDown}
+        placeholder="정렬 선택"
+        width="w-full"
+      />
+
+      {/* 비활성화된 드롭다운 */}
+      <DropDown
+        selected="비활성화됨"
+        options={[]}
+        disabled
+        rightIcon={ChevronDown}
+        width="w-full"
       />
 
       {/* 페이지 링크 */}

--- a/src/pages/TestPage/TestUIPage.tsx
+++ b/src/pages/TestPage/TestUIPage.tsx
@@ -28,12 +28,6 @@ export default function TestUIPage() {
   const sortOptions = ['인기순', '최신순', '가격낮은순', '평점높은순']
   return (
     <div className="space-y-4 p-4">
-      {/* 드롭다운 */}
-      <DropDown
-        dropdownTitle="전체 카테고리"
-        leftIcon={FolderIcon}
-        rightIcon={ChevronDown}
-      />
       {/* 선택 가능한 드롭다운 */}
       <DropDown
         selected={selectedCategory}

--- a/src/pages/TestPage/TestUIPage.tsx
+++ b/src/pages/TestPage/TestUIPage.tsx
@@ -36,7 +36,7 @@ export default function TestUIPage() {
         leftIcon={FolderIcon}
         rightIcon={ChevronDown}
         placeholder="카테고리 선택"
-        width="w-full"
+        className="w-[378px]"
       />
       {/* 정렬 드롭다운 */}
       <DropDown

--- a/src/pages/TestPage/TestUIPage.tsx
+++ b/src/pages/TestPage/TestUIPage.tsx
@@ -45,7 +45,7 @@ export default function TestUIPage() {
         onSelect={setSelectedSort}
         rightIcon={ChevronDown}
         placeholder="정렬 선택"
-        width="w-full"
+        className="w-[378px]"
       />
 
       {/* 비활성화된 드롭다운 */}
@@ -54,7 +54,7 @@ export default function TestUIPage() {
         options={[]}
         disabled
         rightIcon={ChevronDown}
-        width="w-full"
+        className="w-[378px]"
       />
 
       {/* 페이지 링크 */}


### PR DESCRIPTION
## 📌 개요
- 공통 컴포넌트 드롭다운 기능 구현
- 
## 🔧 작업 내용
- [x] TestUIPage 안에서 공통 컴포넌트로 드롭다운 기능 구현 
- [x] 옵션리스트는 상수데이터 ui.ts 에서 가져오지않고 임시로 데이터 만들어놓음 
- [x] 옵션리스트는 ui.ts 에서 추후에 가져올 예정이므로 data 파일에서 가져오지 않고 TextUIPage 에 임시로 선언
- [x] 오른쪽 화살표 아이콘은 드롭다운 선택시 회전하도록 구현

## 📎 관련 이슈

- close #34 

## 📸 스크린샷 (선택)

<img  alt="image" src="https://github.com/user-attachments/assets/cc477738-6734-4582-b80a-2a44196e86de" />
<img  alt="image" src="https://github.com/user-attachments/assets/349c1a4c-4f20-4e06-8330-d9fa02b9cf74" />


## 💬 리뷰어 참고 사항
- 옵션리스트는 ui.ts 에서 추후에 가져올 예정이므로 data 파일에서 가져오지 않고 TextUIPage 에 임시로 선언하였습니다
