### PR TITLE
fix: 스터디 공고 컴포넌트 수정

### DIFF
--- a/src/components/JobPostCard.tsx
+++ b/src/components/JobPostCard.tsx
@@ -2,6 +2,8 @@ import { Bookmark, Calendar, Eye, UsersRound } from 'lucide-react'
 import Badge from './Badge'
 import Icon from './Icon'
 import type { JobPost } from '@src/data/jobPosts'
+import { Link } from 'react-router-dom'
+import { ROUTES } from '@src/constants/routes'
 
 interface JobPostCardProps {
   post: JobPost
@@ -11,6 +13,7 @@ const JobPostCard = ({ post }: JobPostCardProps) => {
   if (!post) return null
 
   const {
+    id,
     title,
     viewCount,
     commentCount,
@@ -22,66 +25,70 @@ const JobPostCard = ({ post }: JobPostCardProps) => {
   } = post
 
   return (
-    <div className="flex h-full gap-4 rounded-lg border border-solid border-gray-200 bg-white p-[25px]">
-      <img
-        src={image}
-        alt={title}
-        className="h-24 w-32 rounded-lg bg-cover bg-center bg-no-repeat"
-      />
-      <div className="flex w-full flex-col">
-        {/* 제목과 조회수, 북마크 수 */}
-        <div className="flex w-full justify-between pb-3">
-          <p className="line-clamp-2 text-lg font-semibold text-gray-900">
-            {title}
-          </p>
-          <div className="text ml-2 flex items-center gap-2">
-            <div className="flex items-center gap-1">
-              <Icon icon={Eye} size="sm" className="stroke-gray-500" />
-              <p className="text-sm text-gray-500">{viewCount}</p>
-            </div>
-            <div className="flex items-center gap-1">
-              <Icon icon={Bookmark} size="sm" className="stroke-gray-500" />
-              <p className="text-sm text-gray-500">{commentCount}</p>
-            </div>
-          </div>
-        </div>
-
-        {/* 모집인원, 마감일 */}
-        <div className="flex flex-col gap-3 pb-4">
-          <div className="flex items-center gap-2">
-            <Icon icon={UsersRound} size="sm" className="stroke-gray-400" />
-            <p className="text-sm text-gray-600">모집 인원: {memberLimit}명</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Icon icon={Calendar} size="sm" className="stroke-gray-400" />
-            <p className="text-sm text-gray-600">마감일: {deadline}</p>
-          </div>
-        </div>
-
-        {/* 강의 목록*/}
-        <div className="flex flex-col gap-2 pb-4">
-          <p className="text-sm text-gray-600">강의 목록:</p>
-          <div className="flex flex-col gap-1">
-            {courses.map((course, courseIndex) => (
-              <div key={courseIndex} className="flex items-center">
-                <p className="text-sm text-gray-700">• {course}</p>
+    <Link to={`${ROUTES.RECRUITMENT}/${id}`}>
+      <div className="flex h-full gap-4 rounded-lg border border-solid border-gray-200 bg-white p-[25px]">
+        <img
+          src={image}
+          alt={title}
+          className="h-24 w-32 rounded-lg bg-cover bg-center bg-no-repeat"
+        />
+        <div className="flex w-full flex-col">
+          {/* 제목과 조회수, 북마크 수 */}
+          <div className="flex w-full justify-between pb-3">
+            <p className="line-clamp-2 text-lg font-semibold text-gray-900">
+              {title}
+            </p>
+            <div className="text ml-2 flex items-start gap-2">
+              <div className="flex items-center gap-1">
+                <Icon icon={Eye} size="sm" className="stroke-gray-500" />
+                <p className="text-sm text-gray-500">{viewCount}</p>
               </div>
+              <div className="flex items-center gap-1">
+                <Icon icon={Bookmark} size="sm" className="stroke-gray-500" />
+                <p className="text-sm text-gray-500">{commentCount}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* 모집인원, 마감일 */}
+          <div className="flex flex-col gap-3 pb-4">
+            <div className="flex items-center gap-2">
+              <Icon icon={UsersRound} size="sm" className="stroke-gray-400" />
+              <p className="text-sm text-gray-600">
+                모집 인원: {memberLimit}명
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Icon icon={Calendar} size="sm" className="stroke-gray-400" />
+              <p className="text-sm text-gray-600">마감일: {deadline}</p>
+            </div>
+          </div>
+
+          {/* 강의 목록*/}
+          <div className="flex flex-col gap-2 pb-4">
+            <p className="text-sm text-gray-600">강의 목록:</p>
+            <div className="flex flex-col gap-1">
+              {courses.map((course, courseIndex) => (
+                <div key={courseIndex} className="flex items-center">
+                  <p className="text-sm text-gray-700">• {course}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 강의 태그 */}
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag, tagIndex) => (
+              <Badge
+                badgeTitle={tag}
+                key={tagIndex}
+                sideClass="bg-primary-100 text-primary-800"
+              />
             ))}
           </div>
         </div>
-
-        {/* 강의 태그 */}
-        <div className="flex flex-wrap gap-2">
-          {tags.map((tag, tagIndex) => (
-            <Badge
-              badgeTitle={tag}
-              key={tagIndex}
-              sideClass="bg-primary-100 text-primary-800"
-            />
-          ))}
-        </div>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/src/components/PageLink.tsx
+++ b/src/components/PageLink.tsx
@@ -23,7 +23,7 @@ const PageLink = ({
   bgColor = 'bg-primary-500',
   borderColor = 'border-primary-500',
   textColor = 'text-primary-600',
-  hoverBgColor = 'hover:bg-primary-50',
+  hoverBgColor,
   hoverTextColor = 'hover:text-primary-600',
   fontWeight = 'normal',
   linkTo = '/',
@@ -34,14 +34,18 @@ const PageLink = ({
     semibold: 'font-semibold',
     bold: 'font-bold',
   }
+
+  const appliedHoverBgColor =
+    variant === 'outline' ? 'hover:bg-primary-50' : 'hover:bg-primary-600'
+
   const getStyles = () => {
     switch (variant) {
       case 'ghost':
         return `${textColor} ${hoverTextColor} transition-colors px-2`
       case 'outline':
-        return `border-1 ${borderColor} ${textColor} ${hoverBgColor} transition-colors px-6 py-2 rounded-lg`
+        return `border-1 ${borderColor} ${textColor} ${hoverBgColor || appliedHoverBgColor}  transition-colors px-6 py-2 rounded-lg`
       default:
-        return `${bgColor} text-white ${hoverBgColor || 'hover:bg-primary-600'} transition-colors px-6 py-2 rounded-lg`
+        return `${bgColor} text-white ${hoverBgColor || appliedHoverBgColor} transition-colors px-6 py-2 rounded-lg`
     }
   }
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,8 +1,16 @@
 export const ROUTES = {
   HOME: '/',
   COURSES: '/courses',
+  MYPAGE: '/mypage',
   STUDY_GROUP: '/study-group',
+  STUDY_GROUP_ID: '/study-group/:id',
+  STUDY_GROUP_CREATE: '/study-group/create',
   RECRUITMENT: '/recruitment',
+  RECRUITMENT_ID: '/recruitment/:id',
+  RECRUITMENT_CREATE: '/recruitment/create',
   RECRUITMENT_MANAGE: '/recruitment/manage',
-  LOGIN: '/login',
+  LOGIN: '/auth/login',
+  SIGNUP: '/auth/signup',
+  FIND_EMAIL: '/auth/find-email',
+  FIND_PASSWORD: '/auth/find-password',
 } as const

--- a/src/pages/RecruitmentPage/Anonymous.tsx
+++ b/src/pages/RecruitmentPage/Anonymous.tsx
@@ -15,7 +15,11 @@ export default function Anonymous() {
         <p>를 추천해드립니다</p>
       </div>
       <div className="flex gap-4">
-        <PageLink pageLinkInnerText="로그인 하기" icon={LogIn} />
+        <PageLink
+          pageLinkInnerText="로그인 하기"
+          variant="filled"
+          icon={LogIn}
+        />
         <PageLink
           pageLinkInnerText="회원가입하기"
           icon={UserPlus}

--- a/src/pages/RecruitmentPage/Anonymous.tsx
+++ b/src/pages/RecruitmentPage/Anonymous.tsx
@@ -1,4 +1,5 @@
 import PageLink from '@components/PageLink'
+import { ROUTES } from '@src/constants/routes'
 import { LogIn, User, UserPlus } from 'lucide-react'
 
 export default function Anonymous() {
@@ -19,10 +20,12 @@ export default function Anonymous() {
           pageLinkInnerText="로그인 하기"
           variant="filled"
           icon={LogIn}
+          linkTo={ROUTES.LOGIN}
         />
         <PageLink
           pageLinkInnerText="회원가입하기"
           icon={UserPlus}
+          linkTo={ROUTES.SIGNUP}
           variant="outline"
         />
       </div>


### PR DESCRIPTION
## 📌 개요
스터디 공고 컴포넌트 수정

## 🔧 작업 내용

- 깨진 버튼 UI 수정
- 라우트 path 추가
- 버튼 클릭 시 페이지 이동 추가
- 스터디 공고 카드 클릭 시 상세 페이지 이동 추가

## 📎 관련 이슈
closes #33 

## 📸 스크린샷
<img width="484" height="253" alt="image" src="https://github.com/user-attachments/assets/d7e023d0-19d5-4b35-875a-1bcd56b928a9" />

버튼 클릭 시 페이지 이동 구현
<img width="285" height="62" alt="image" src="https://github.com/user-attachments/assets/09088c4d-1a92-4d7f-83c6-823d8a2365d7" />

