### PR TITLE
feat: 애니메이션 프리셋 상수화 #51

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
         "lucide-react": "^0.515.0",
+        "motion": "^12.23.12",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.62.0",
@@ -1924,9 +1925,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.85.9",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.9.tgz",
-      "integrity": "sha512-5fxb9vwyftYE6KFLhhhDyLr8NO75+Wpu7pmTo+TkwKmMX2oxZDoLwcqGP8ItKSpUMwk3urWgQDZfyWr5Jm9LsQ==",
+      "version": "5.86.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.86.0.tgz",
+      "integrity": "sha512-Y6ibQm6BXbw6w1p3a5LrPn8Ae64M0dx7hGmnhrm9P+XAkCCKXOwZN0J5Z1wK/0RdNHtR9o+sWHDXd4veNI60tQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1934,12 +1935,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.85.9",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.9.tgz",
-      "integrity": "sha512-2T5zgSpcOZXGkH/UObIbIkGmUPQqZqn7esVQFXLOze622h4spgWf5jmvrqAo9dnI13/hyMcNsF1jsoDcb59nJQ==",
+      "version": "5.86.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.86.0.tgz",
+      "integrity": "sha512-jgS/v0oSJkGHucv9zxOS8rL7mjATh1XO3K4eqAV4WMpAly8okcBrGi1YxRZN5S4B59F54x9JFjWrK5vMAvJYqA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.85.9"
+        "@tanstack/query-core": "5.86.0"
       },
       "funding": {
         "type": "github",
@@ -2008,9 +2009,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3779,6 +3780,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5076,6 +5104,47 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+      "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.12",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6378,7 +6447,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
     "lucide-react": "^0.515.0",
+    "motion": "^12.23.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.62.0",

--- a/src/constants/animations.ts
+++ b/src/constants/animations.ts
@@ -1,27 +1,22 @@
 import type { Variants } from 'framer-motion'
 
-export const fade: Variants = {
-  initial: { opacity: 0 },
-  animate: { opacity: 1 },
-  exit: { opacity: 0 },
-}
-
-export const scaleUp: Variants = {
-  initial: { opacity: 0, scale: 0.95 },
-  animate: { opacity: 1, scale: 1 },
-  exit: { opacity: 0, scale: 0.98 },
-}
-
-export const slideUp: Variants = {
-  initial: { opacity: 0, y: 16 },
-  animate: { opacity: 1, y: 0 },
-  exit: { opacity: 0, y: 8 },
-}
-
 export const ANIMATIONS = {
-  fade,
-  scaleUp,
-  slideUp,
+  fade: {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+  },
+  scaleUp: {
+    initial: { opacity: 0, scale: 0.95 },
+    animate: { opacity: 1, scale: 1 },
+    exit: { opacity: 0, scale: 0.98 },
+  },
+  slideUp: {
+    initial: { opacity: 0, y: 16 },
+    animate: { opacity: 1, y: 0 },
+    exit: { opacity: 0, y: 8 },
+  },
+  //추가 하고 싶은 에니메이션은 밑에다 추가
 } as const
 
 export type AnimationKey = keyof typeof ANIMATIONS

--- a/src/constants/animations.ts
+++ b/src/constants/animations.ts
@@ -1,0 +1,45 @@
+import type { Variants } from 'framer-motion'
+
+export const fade: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+}
+
+export const scaleUp: Variants = {
+  initial: { opacity: 0, scale: 0.95 },
+  animate: { opacity: 1, scale: 1 },
+  exit: { opacity: 0, scale: 0.98 },
+}
+
+export const slideUp: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: 8 },
+}
+
+export const ANIMATIONS = {
+  fade,
+  scaleUp,
+  slideUp,
+} as const
+
+export type AnimationKey = keyof typeof ANIMATIONS
+
+export type Speed = 'fast' | 'normal' | 'slow'
+export const speedToTransition = {
+  fast: { duration: 0.15, ease: 'easeOut' },
+  normal: { duration: 0.25, ease: 'easeOut' },
+  slow: { duration: 0.4, ease: 'easeOut' },
+} as const
+
+export function applySpeed(v: Variants, speed: Speed): Variants {
+  return {
+    ...v,
+    animate: {
+      ...(v.animate ?? {}),
+      transition: { ...speedToTransition[speed] },
+    },
+    exit: { ...(v.exit ?? {}), transition: { ...speedToTransition[speed] } },
+  }
+}

--- a/src/types/motion.ts
+++ b/src/types/motion.ts
@@ -1,0 +1,15 @@
+import type { AnimationKey, Speed } from '@src/constants/animations'
+import type { Variants } from 'framer-motion'
+
+export interface MotionOptions {
+  //'fade' | 'scaleUp' | 'slideUp'
+  animation?: AnimationKey
+  //완전 커스텀 variants 직접 전달
+  variants?: Variants
+  // 속도: 'fast' | 'normal' | 'slow'
+  speed?: Speed
+  // 상태 키 커스터마이즈가 필요할 때만 사용
+  initial?: string
+  animate?: string
+  exit?: string
+}


### PR DESCRIPTION
## 📌 개요

- 공통 애니메이션 프리셋(fade, scaleUp, slideUp), 속도 옵션(fast/normal/slow)을 추가

## 🔧 작업 내용

- [x] ANIMATIONS 상수 추가 (fade, scaleUp, slideUp)
- [x] Speed 프리셋 정의 (fast, normal, slow)
- [x] MotionOptions 타입 정의 → 공통 컴포넌트에서 motion prop으로 애니메이션 지정 가능

## 📎 관련 이슈
- closes #51 
## 💬 리뷰어 참고 사항

사용 예시
```
<motion.div
  variants={ANIMATIONS.scaleUp}
  initial="initial"
  animate="animate"
  exit="exit"
>
  콘텐츠
</motion.div>

<BaseModal
  open={open}
  onClose={onClose}
  motion={{ animation: 'fade', speed: 'fast' }}
>
  내용
</BaseModal>
```

- 추후 Modal, Toast, Dropdown 등 공통 컴포넌트에 motion prop을 적용할 수 있습니다.
- 속도 옵션은 fast/normal/slow 프리셋만 지원하며, 필요 시 프리셋 확장 가능

