### PR TITLE
refactor: 스터디 구인 공고 관리 페이지

### DIFF
--- a/src/components/JobPostCard.tsx
+++ b/src/components/JobPostCard.tsx
@@ -42,15 +42,11 @@ export default function JobPostCard({
   return (
     <Link to={`${ROUTES.RECRUITMENT}/${id}`}>
       <div className="flex h-full gap-4 rounded-lg border border-solid border-gray-200 bg-white p-[25px]">
-        {image ? (
-          <img
-            src={image}
-            alt={title}
-            className="h-24 w-32 rounded-lg bg-cover bg-center bg-no-repeat object-cover"
-          />
-        ) : (
-          <div className="h-24 w-32 rounded-lg bg-gray-100" />
-        )}
+        <img
+          src={image || 'https://placehold.co/320x240/e5e7eb/e5e7eb.png'}
+          alt={title}
+          className="h-24 w-32 rounded-lg object-cover"
+        />
 
         <div className="flex w-full flex-col">
           {/* 제목과 조회수/댓글 + (옵션) 편집 버튼 */}

--- a/src/components/recruitment/common/BackButton.tsx
+++ b/src/components/recruitment/common/BackButton.tsx
@@ -15,7 +15,7 @@ export default function BackButton() {
   return (
     <button
       onClick={handleBack}
-      className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[#F3F4F6] transition-colors delay-200 duration-300 hover:cursor-pointer hover:bg-[#cbcdcf] hover:delay-100"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 transition-colors delay-0 duration-300 hover:cursor-pointer hover:bg-gray-200"
     >
       <ArrowLeftIcon size={20} strokeWidth={2} />
     </button>

--- a/src/components/recruitment/common/SelectRecDropDown.tsx
+++ b/src/components/recruitment/common/SelectRecDropDown.tsx
@@ -4,6 +4,7 @@ import {
   Folder as FolderIcon,
 } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { Z_INDEX } from '@src/constants/ui'
 
 const SORT_OPTION = ['최신순', '조회수 높은 순', '북마크 많은 순']
 const STATUS_OPTION = ['전체 (4)', '모집중 (2)', '마감됨 (1)']
@@ -40,7 +41,7 @@ export default function SelectRecDropDown({ variant }: Props) {
       {open && (
         <ul
           role="listbox"
-          className="absolute right-0 left-0 z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-gray-200 bg-white shadow"
+          className={`z-[${Z_INDEX.DROPDOWN}] absolute right-0 left-0 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-gray-200 bg-white shadow`}
         >
           {options.map((option) => (
             <li

--- a/src/components/recruitment/manage/RecManageList.tsx
+++ b/src/components/recruitment/manage/RecManageList.tsx
@@ -1,31 +1,21 @@
 import JobPostCard from '@src/components/JobPostCard'
-import DUMMYCARDSVG from '@assets/card_click_dummy.svg'
 import { useNavigate } from 'react-router-dom'
+import { jobPosts } from '@mock/jobPosts'
 
 type CardProps = Parameters<typeof JobPostCard>[0]
 
 export default function RecManageList() {
   const navigate = useNavigate()
 
-  const items: CardProps[] = Array.from({ length: 4 }, (_, idx) => {
-    const id = idx + 1
-    return {
-      post: {
-        id,
-        title: 'Unity 게임 개발 프로젝트 팀원 모집',
-        viewCount: 412,
-        commentCount: 105,
-        memberLimit: 0,
-        deadline: '2025. 12. 30.',
-        courses: ['Unity 게임 개발 마스터클래스 - 박유니티'],
-        tags: ['Unity', '게임개발', '3D게임'],
-        image: DUMMYCARDSVG,
-      },
-      editTo: `/recruitment/${id}/edit`,
-      applyLabel: '지원 내역',
-      onClickApply: () => navigate(`/recruitment/create`),
-    }
-  })
+  const items: CardProps[] = jobPosts.map((post) => ({
+    post: {
+      ...post,
+      image: post.image,
+    },
+    editTo: `/recruitment/${post.id}/edit`,
+    applyLabel: '지원 내역',
+    onClickApply: () => navigate(`/recruitment/create`),
+  }))
 
   return (
     <section>

--- a/src/pages/test-page/TestHub.tsx
+++ b/src/pages/test-page/TestHub.tsx
@@ -6,7 +6,10 @@ interface TestPage {
   label: string
 }
 
-const pageItems: TestPage[] = [{ to: ROUTES.RECRUITMENT, label: '공고 페이지' }]
+const pageItems: TestPage[] = [
+  { to: ROUTES.RECRUITMENT, label: '공고 페이지' },
+  { to: ROUTES.RECRUITMENT_MANAGE, label: '공고 관리 페이지' },
+]
 
 const testItems: TestPage[] = [
   { to: '/test/ApplicationModal', label: '지원서 작성 모달 테스트' },


### PR DESCRIPTION
## 📌 개요

- PR 번호 #63 에 받은 코멘트 수정 작업

## 🔧 작업 내용

- [x] `BackButton` 스타일 가이드 참고하여 수정.
- [x] `JobPostCard`: fallback 활용
- [x] 테스트허브 및 라우트에 추가
- [x] `SelectRecDropDown`: ui.ts에 추가 되어 있는 상수화 반영.
- [x] `RecManageList`: 스터디 공고 더미데이터 & interface 활용, 

## 📎 관련 이슈

closes #74 

## 💬 리뷰어 참고 사항

- #63 에서 받은 리뷰 사항들 반영했습니다.
