### PR TITLE
refactor: 알림 아이콘 및 탭 스타일 cva 적용 및 HeaderUserSection 리팩토링 (#78)

### DIFF
--- a/src/components/header/components/Navigation.tsx
+++ b/src/components/header/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import { NAV_ITEMS } from '@src/constants/ui'
 import { Link } from 'react-router-dom'
-import HeaderUserSection from './HeaderUserSection'
+import HeaderUserSection from './user-section/HeaderUserSection'
 
 export default function Navigation() {
   return (

--- a/src/components/header/components/user-section/HeaderUserSection.tsx
+++ b/src/components/header/components/user-section/HeaderUserSection.tsx
@@ -1,7 +1,7 @@
 import Button from '@src/components/button/Button'
 import Icon from '@components/Icon'
 import PageLink from '@components/PageLink'
-import { NOTIFICATION_ICON_CONFIG, Z_INDEX } from '@constants/ui'
+import { Z_INDEX } from '@constants/ui'
 import notificationsData from '@mock/notificationsData'
 import { ROUTES } from '@src/constants/routes'
 import type { NotificationItem } from '@src/types/notification'
@@ -16,35 +16,35 @@ import {
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import {
+  notificationIconClass,
+  notificationIconStrokeClass,
+  tabClass,
+} from './notificationIconClass'
+
+const iconMap = {
+  application: UserRoundPlusIcon,
+  approval: CheckIcon,
+  rejection: CloseIcon,
+  join: UsersRoundIcon,
+  study_end: CalendarCheckIcon,
+  reminder: BellIcon,
+}
 
 const getNotificationIcon = (type: NotificationItem['type']) => {
-  const config = NOTIFICATION_ICON_CONFIG.find((item) => item.type === type)
-
-  if (!config) {
-    return (
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100">
-        <div className="h-5 w-5 rounded-full bg-gray-500" />
-      </div>
-    )
-  }
-  const IconComponent = iconMap[config.icon as keyof typeof iconMap]
-  // "config.icon은 iconMap의 키 중 하나야"라고 알려주는 것
+  const IconComponent = iconMap[type] || BellIcon
 
   return (
-    <div
-      className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${config.bgColor}`}
-    >
-      <Icon icon={IconComponent} className={config.strokeColor} size="s" />
+    <div className={notificationIconClass({ type })}>
+      <Icon
+        icon={IconComponent}
+        className={notificationIconStrokeClass({ type })}
+        size="s"
+      />
     </div>
   )
 }
-const iconMap = {
-  UserRoundPlusIcon,
-  CheckIcon,
-  CloseIcon,
-  UsersRoundIcon,
-  CalendarCheckIcon,
-}
+
 export default function HeaderUserSection() {
   const navigate = useNavigate()
   const [isNotificationOpen, setIsNotificationOpen] = useState(false)
@@ -138,22 +138,18 @@ export default function HeaderUserSection() {
                   <div
                     role="tab"
                     onClick={() => setNotificationFilter('all')}
-                    className={`flex w-2/3 items-center justify-center pt-3 pb-3.5 text-sm ${
-                      notificationFilter === 'all'
-                        ? 'border-primary-500 text-primary-600 border-b-2'
-                        : 'border-b-2 border-transparent text-gray-500'
-                    }`}
+                    className={tabClass({
+                      active: notificationFilter === 'all',
+                    })}
                   >
                     전체보기 ({notifications.length})
                   </div>
                   <div
                     role="tab"
                     onClick={() => setNotificationFilter('unread')}
-                    className={`flex w-2/3 items-center justify-center pt-3 pb-3.5 text-sm ${
-                      notificationFilter === 'unread'
-                        ? 'border-primary-500 text-primary-600 border-b-2'
-                        : 'border-b-2 border-transparent text-gray-500'
-                    }`}
+                    className={tabClass({
+                      active: notificationFilter === 'unread',
+                    })}
                   >
                     읽지 않음 (
                     {
@@ -166,11 +162,9 @@ export default function HeaderUserSection() {
                   <div
                     role="tab"
                     onClick={() => setNotificationFilter('read')}
-                    className={`flex w-2/3 items-center justify-center pt-3 pb-3.5 text-sm ${
-                      notificationFilter === 'read'
-                        ? 'border-primary-500 text-primary-600 border-b-2'
-                        : 'border-b-2 border-transparent text-gray-500'
-                    }`}
+                    className={tabClass({
+                      active: notificationFilter === 'read',
+                    })}
                   >
                     읽음 (
                     {

--- a/src/components/header/components/user-section/notificationIconClass.ts
+++ b/src/components/header/components/user-section/notificationIconClass.ts
@@ -1,0 +1,52 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export const notificationIconClass = cva(
+  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+  {
+    variants: {
+      type: {
+        application: 'bg-blue-100',
+        approval: 'bg-green-100',
+        rejection: 'bg-red-100',
+        join: 'bg-purple-100',
+        study_end: 'bg-orange-100',
+        reminder: 'bg-gray-100',
+      },
+    },
+    defaultVariants: {
+      type: 'reminder',
+    },
+  }
+)
+
+export const notificationIconStrokeClass = cva('', {
+  variants: {
+    type: {
+      application: 'stroke-[#2563EB]',
+      approval: 'stroke-[#16A34A]',
+      rejection: 'stroke-[#DC2626]',
+      join: 'stroke-[#9333EA]',
+      study_end: 'stroke-[#EA580C]',
+      reminder: 'stroke-gray-400',
+    },
+  },
+  defaultVariants: {
+    type: 'reminder',
+  },
+})
+
+export type NotificationIconClassProps = VariantProps<
+  typeof notificationIconClass
+>
+
+export const tabClass = cva(
+  'flex w-2/3 items-center justify-center pt-3 pb-3.5 text-sm border-b-2 transition-colors cursor-pointer',
+  {
+    variants: {
+      active: {
+        true: 'border-primary-500 text-primary-600',
+        false: 'border-transparent text-gray-500',
+      },
+    },
+  }
+)

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -174,39 +174,6 @@ export const NOTIFICATION_TYPE = {
   REMINDER: 'reminder',
 } as const
 
-export const NOTIFICATION_ICON_CONFIG = [
-  {
-    type: NOTIFICATION_TYPE.APPLICATION,
-    bgColor: 'bg-blue-100',
-    strokeColor: 'stroke-[#2563EB]',
-    icon: 'UserRoundPlus',
-  },
-  {
-    type: NOTIFICATION_TYPE.APPROVAL,
-    bgColor: 'bg-green-100',
-    strokeColor: 'stroke-[#16A34A]',
-    icon: 'Check',
-  },
-  {
-    type: NOTIFICATION_TYPE.REJECTION,
-    bgColor: 'bg-red-100',
-    strokeColor: 'stroke-[#DC2626]',
-    icon: 'X',
-  },
-  {
-    type: NOTIFICATION_TYPE.JOIN,
-    bgColor: 'bg-purple-100',
-    strokeColor: 'stroke-[#9333EA]',
-    icon: 'UsersRound',
-  },
-  {
-    type: NOTIFICATION_TYPE.STUDY_END,
-    bgColor: 'bg-orange-100',
-    strokeColor: 'stroke-[#EA580C]',
-    icon: 'CalendarCheck',
-  },
-]
-
 export const Z_INDEX = {
   HEADER: 100,
   DROPDOWN: 200,

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -3,7 +3,8 @@
   font-weight: 100 900;
   font-style: normal;
   font-display: swap;
-  src: url('/assets/fonts/PretendardVariable.woff2') format('woff2-variations');
+  src: url('../assets/fonts/PretendardVariable.woff2')
+    format('woff2-variations');
 }
 
 html {


### PR DESCRIPTION
## 📌 개요
- 알림 아이콘 및 탭 스타일 cva 적용 및 HeaderUserSection 리팩토링

## 🔧 작업 내용

- [ ] 알림 아이콘 배경/선색 스타일을 notificationIconClass, notificationIconStrokeClass cva로 분리 관리
- [ ] HeaderUserSection에서 알림 아이콘 렌더링 시 cva 기반 스타일 적용
- [ ] 탭 버튼 스타일도 cva(tabClass)로 일관성 있게 관리
- [ ] NOTIFICATION_ICON_CONFIG 제거, iconMap 및 cva만으로 스타일링
- [ ] Navigation에서 HeaderUserSection 경로 및 구조 정리

## 📎 관련 이슈

closes #78 

## 📸 스크린샷 (선택)


## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
