### PR TITLE
refactor: PageLink 및 관련 컴포넌트 구조 개선(#83)

### DIFF
--- a/src/components/header/components/user-section/HeaderUserSection.tsx
+++ b/src/components/header/components/user-section/HeaderUserSection.tsx
@@ -1,6 +1,5 @@
-import Button from '@src/components/button/Button'
 import Icon from '@components/Icon'
-import PageLink from '@components/PageLink'
+import PageLink from '@components/page-link/PageLink'
 import { Z_INDEX } from '@constants/ui'
 import notificationsData from '@mock/notificationsData'
 import { ROUTES } from '@src/constants/routes'
@@ -39,7 +38,7 @@ const getNotificationIcon = (type: NotificationItem['type']) => {
       <Icon
         icon={IconComponent}
         className={notificationIconStrokeClass({ type })}
-        size="s"
+        size="sm"
       />
     </div>
   )
@@ -53,13 +52,21 @@ export default function HeaderUserSection() {
   const [notificationFilter, setNotificationFilter] = useState<
     'all' | 'unread' | 'read'
   >('all')
+
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
+
   // 개발단계에선 해당 값을 true 와 false 로 합니다.
   const user = true
 
   const notificationRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
+
   const handleNotificationToggle = () => {
     setIsNotificationOpen(!isNotificationOpen)
+  }
+
+  const handleAvatarToggle = () => {
+    setIsUserMenuOpen(!isUserMenuOpen)
   }
 
   const handleMarkAllAsRead = () => {
@@ -119,7 +126,7 @@ export default function HeaderUserSection() {
             {isNotificationOpen && (
               <div
                 ref={notificationRef}
-                className={`absolute top-12 right-0 z-[${Z_INDEX.DROPDOWN}] max-h-[819.2px] w-96 overflow-hidden rounded-lg border border-gray-200 bg-white`}
+                className={`absolute top-12 right-0 z-[${Z_INDEX.DROPDOWN}] max-h-[819.2px] overflow-hidden rounded-lg border border-gray-200 bg-white`}
                 onClick={(e) => e.stopPropagation()}
               >
                 <div className="flex items-center justify-between px-4 pt-4 pb-[17px]">
@@ -191,10 +198,9 @@ export default function HeaderUserSection() {
                       >
                         {getNotificationIcon(notification.type)}
                         <div className="flex flex-col gap-1">
-                          <p className="line-clamp-2 text-left text-sm text-gray-900">
+                          <p className="line-clamp-2 min-w-72 text-left text-sm text-gray-900">
                             {notification.message}
                           </p>
-                          {/* </div> */}
                           <p className="flex items-center text-xs text-gray-500">
                             {notification.date}
                           </p>
@@ -212,7 +218,10 @@ export default function HeaderUserSection() {
               </div>
             )}
           </button>
-          <a className="flex items-center gap-2">
+          <div
+            className="relative flex items-center gap-2"
+            onClick={handleAvatarToggle}
+          >
             <div className="bg-primary-100 flex h-8 w-8 items-center justify-center rounded-full">
               <Icon
                 icon={UserRoundIcon}
@@ -221,22 +230,42 @@ export default function HeaderUserSection() {
               />
             </div>
             <p className="text-base text-gray-700">김스터디</p>
-          </a>
+            {isUserMenuOpen && (
+              <div
+                className={`absolute top-12 right-0 z-[${Z_INDEX.DROPDOWN}] w-48 rounded-lg border border-gray-200 bg-white py-2`}
+              >
+                <PageLink
+                  pageLinkInnerText="마이페이지"
+                  variant="ghost"
+                  link="/profile"
+                  className="text-sm"
+                  fontWeight="normal"
+                />
+                <PageLink
+                  pageLinkInnerText="로그아웃"
+                  variant="ghost"
+                  link="/logout"
+                  className="text-sm"
+                  fontWeight="normal"
+                />
+              </div>
+            )}
+          </div>
         </>
       ) : (
         <>
           <PageLink
             pageLinkInnerText="로그인"
             variant="ghost"
-            hoverTextColor="text-gray-700"
             fontWeight="normal"
-            linkTo="/login"
+            link="/login"
           />
-          <Button
-            buttonInnerText="회원가입"
+          <PageLink
+            pageLinkInnerText="회원가입"
+            variant="filled"
             size="base"
-            variant="primary"
             fontWeight="medium"
+            link="/signup"
           />
         </>
       )}

--- a/src/components/page-link/PageLink.tsx
+++ b/src/components/page-link/PageLink.tsx
@@ -1,0 +1,55 @@
+import { Link } from 'react-router-dom'
+import { pageLinkClass, type PageLinkClassProps } from './linkClass'
+import Icon from '@components/Icon'
+import type { LucideIcon } from 'lucide-react'
+import type { LinkHTMLAttributes } from 'react'
+import { cn } from '@utils/cn'
+
+interface PageLinkProps
+  extends LinkHTMLAttributes<HTMLAnchorElement>,
+    PageLinkClassProps {
+  pageLinkInnerText: string
+  icon?: LucideIcon
+  iconClassName?: string
+  iconSize?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  iconButtonSize?: 'sm' | 'md' | 'lg' | 'xl'
+  ariaLabel?: string
+  link: string
+}
+
+export default function PageLink({
+  pageLinkInnerText,
+  icon,
+  iconClassName,
+  size = 'base',
+  iconButtonSize = 'md',
+  variant = 'filled',
+  fontWeight,
+  iconSize = 'sm',
+  ariaLabel,
+  link,
+  className,
+  ...props
+}: PageLinkProps) {
+  const iconOnly = !!icon && !pageLinkInnerText
+  return (
+    <Link
+      className={cn(
+        pageLinkClass({
+          size: !iconOnly ? size : undefined,
+          iconButtonSize: iconOnly ? iconButtonSize : undefined,
+          variant,
+          fontWeight,
+          iconOnly,
+        }),
+        className
+      )}
+      to={link}
+      aria-label={ariaLabel || pageLinkInnerText}
+      {...props}
+    >
+      {icon && <Icon icon={icon} size={iconSize} className={iconClassName} />}
+      {pageLinkInnerText}
+    </Link>
+  )
+}

--- a/src/components/page-link/linkClass.ts
+++ b/src/components/page-link/linkClass.ts
@@ -1,0 +1,43 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export const pageLinkClass = cva(
+  'flex items-center gap-2 font-medium cursor-pointer w-fit',
+  {
+    variants: {
+      variant: {
+        filled: 'bg-primary-500 text-white rounded-lg',
+        outline:
+          'bg-white text-primary-600 border border-primary-500 rounded-lg',
+        ghost: 'bg-transparent text-primary-600 rounded-lg',
+        text: 'bg-transparent text-gray-700',
+      },
+      size: {
+        sm: 'px-3 py-2 text-sm rounded-md',
+        base: 'px-4 py-2.5 text-sm rounded-lg',
+        lg: 'px-6 py-3 text-base rounded-lg',
+      },
+      iconButtonSize: {
+        sm: 'w-8 h-8 p-0 rounded-full',
+        md: 'w-10 h-10 p-0 rounded-full',
+        lg: 'w-12 h-12 p-0 rounded-full',
+        xl: 'w-16 h-16 p-0 rounded-full',
+      },
+      iconOnly: {
+        true: '',
+        false: '',
+      },
+      fontWeight: {
+        normal: 'font-normal',
+        medium: 'font-medium',
+        semibold: 'font-semibold',
+        bold: 'font-bold',
+      },
+    },
+    defaultVariants: {
+      variant: 'filled',
+      size: 'base',
+    },
+  }
+)
+
+export type PageLinkClassProps = VariantProps<typeof pageLinkClass>

--- a/src/components/recruitment/manage/RecManageHeader.tsx
+++ b/src/components/recruitment/manage/RecManageHeader.tsx
@@ -1,6 +1,6 @@
-import Button from '@src/components/button/Button'
 import BackButton from '../common/BackButton'
 import { Plus as PlusIcon } from 'lucide-react'
+import PageLink from '@src/components/page-link/PageLink'
 
 export default function RecManageHeader() {
   return (
@@ -19,13 +19,13 @@ export default function RecManageHeader() {
       </div>
 
       {/* 공고관리 header right */}
-      <div>
-        <Button
-          buttonInnerText="새 공고 작성하기"
-          icon={PlusIcon}
-          variant="primary"
-        />
-      </div>
+      <PageLink
+        pageLinkInnerText="새 공고 작성하기"
+        icon={PlusIcon}
+        variant="filled"
+        size="lg"
+        link="/recruitment/create"
+      />
     </div>
   )
 }

--- a/src/pages/recruitment-page/Anonymous.tsx
+++ b/src/pages/recruitment-page/Anonymous.tsx
@@ -1,4 +1,4 @@
-import PageLink from '@components/PageLink'
+import PageLink from '@src/components/page-link/PageLink'
 import { ROUTES } from '@src/constants/routes'
 import {
   LogIn as LogInIcon,
@@ -24,13 +24,15 @@ export default function Anonymous() {
           pageLinkInnerText="로그인 하기"
           variant="filled"
           icon={LogInIcon}
-          linkTo={ROUTES.LOGIN}
+          size="lg"
+          link={ROUTES.LOGIN}
         />
         <PageLink
           pageLinkInnerText="회원가입하기"
           icon={UserPlusIcon}
-          linkTo={ROUTES.SIGNUP}
+          link={ROUTES.SIGNUP}
           variant="outline"
+          size="base"
         />
       </div>
       <div className="mt-8 flex flex-col gap-4 text-center">


### PR DESCRIPTION
## 📌 개요
PageLink 및 관련 컴포넌트 구조 개선

## 🔧 작업 내용
- [ ] PageLink 컴포넌트 iconOnly/아이콘+텍스트/텍스트-only 일관성 있게 지원 (iconButtonSize, iconSize prop 추가)
- [ ] linkClass: iconButtonSize, iconOnly variant 추가 및 스타일 분리
- [ ] RecManageHeader, Anonymous, HeaderUserSection 등에서 PageLink 최신 사용법 적용
- [ ] PageLink의 접근성(ariaLabel) 및 props 구조 개선
- [ ] 전체적으로 PageLink와 버튼류 컴포넌트의 사용성과 일관성 강화
- [ ] 
## 📎 관련 이슈

closes #83 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항
PageLink 컴포넌트에 cva 스타일 시스템을 적용하였습니다.

<PageLink 컴포넌트 사용법 가이드>

1. 기본 사용법
```
import PageLink from '@components/page-link/PageLink'

// 기본(filled) 링크 버튼
<PageLink pageLinkInnerText="공고 작성" link="/recruitment/create" />

// outline 링크 버튼
<PageLink pageLinkInnerText="로그인" variant="outline" link="/login" />

// ghost(투명) 링크 버튼
<PageLink pageLinkInnerText="더보기" variant="ghost" link="/more" />

// 텍스트-only 링크
<PageLink pageLinkInnerText="회원가입" variant="text" link="/signup" />

// 아이콘만 있는 링크
<PageLink icon={SomeIcon} iconButtonSize="md" ariaLabel="알림" link="/notification" />

// 아이콘 + 텍스트 (gap 8px 자동 적용)
<PageLink pageLinkInnerText="새 공고" icon={PlusIcon} link="/recruitment/create" />

// 비활성화
<PageLink pageLinkInnerText="비활성화" disabled link="#" />
```

2. 주요 Props

|prop | 설명 | 타입/예시|
|-- | -- | --|
|`pageLinkInnerText` | 링크에 표시할 텍스트 | `"공고 작성"`|
|`link` | 이동할 경로 | `"/recruitment/create"`|
|`variant` | 스타일 (filled, outline, ghost, text) | `"filled"` `"outline"` 등|
|`size` | 크기 (sm, base, lg) | `"sm"` `"base"` `"lg"`|
|`icon` | 아이콘 컴포넌트 (lucide-react 등) | `{PlusIcon}`|
|`iconButtonSize` | 아이콘-only 링크의 버튼 크기 | `"sm"` `"md"` `"lg"` `"xl"`|
|`iconSize` | 아이콘 SVG 크기 | `"xs"` `"sm"` `"md"` `"lg"` `"xl"` 또는 숫자|
|`fontWeight` | 폰트 굵기 (normal, medium, semibold, bold) | `"medium"`|
|`disabled` | 비활성화 | `true`/`false`
|`className` | 추가 커스텀 클래스 | `"w-full"` 등
|`ariaLabel` | 접근성용 레이블 (아이콘-only일 때 필수) | `"알림"` 등

> iconOnly prop은 사용하지 않습니다.
아이콘만 전달하고 텍스트가 없으면 자동으로 아이콘-only 링크로 처리됩니다.

3. 아이콘과 텍스트 조합 시 gap 안내
- 아이콘과 텍스트를 함께 사용하면 내부에 자동으로 `gap-2`(8px)가 적용되어 일관된 간격이 유지됩니다.
- 아이콘-only 링크는 gap이 적용되지 않고, 완전히 동그란 스타일로 나옵니다.

4. `linkClass` 코드 설명
- `linkClass`는 `class-variance-authority(cva)`를 사용하여, PageLink의 스타일을 variant/size 등 props로 쉽게 관리할 수 있게 해주는 함수입니다.
- 예를 들어, `variant="outline"`과 `size="lg"`를 주면 디자인 시스템에 맞는 Tailwind 클래스를 자동으로 조합해줍니다.
- 색상, 크기, 폰트 굵기, 아이콘-only 전용 크기(iconButtonSize) 등 다양한 스타일을 props로만 조절할 수 있어, 일관된 UI를 쉽게 만들 수 있습니다.

5. linkClass 주요 옵션
- `variant`: 
       - `filled` : 배경 컬러 
       - `outline` : 테두리만 있는 링크 
       - `ghost` : 배경 없는 투명 링크 
       - `text` : 텍스트만 있는 링크
- `size`: 
      - `sm`, `base`, `lg`
- `iconButtonSize`: 아이콘-only 링크일 때 버튼 크기 조절
- `fontWeight`: 폰트 굵기 조절

6. 예시
```<PageLink
  pageLinkInnerText="삭제"
  variant="danger"
  size="lg"
  icon={TrashIcon}
  fontWeight="bold"
  link="/delete"
/>

<PageLink
  icon={BellIcon}
  iconButtonSize="md"
  iconSize="md"
  ariaLabel="알림"
  link="/notification"
/>
```
