### PR TITLE
feat: HeaderUserSection 에서 마이페이지와 로그아웃 할수 있는 ui 구현

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -5,7 +5,7 @@ import Navigation from './components/Navigation'
 export default function Header() {
   return (
     <header
-      className={`sticky top-0 z-[${Z_INDEX.HEADER}] flex h-16 w-full items-center justify-center px-20`}
+      className={`sticky top-0 z-[${Z_INDEX.HEADER}] flex h-16 w-full items-center justify-center border-b border-gray-200 px-20`}
     >
       <div className="flex h-full w-full max-w-7xl justify-between bg-white px-8">
         <Logo />

--- a/src/components/header/components/user-section/HeaderUserSection.tsx
+++ b/src/components/header/components/user-section/HeaderUserSection.tsx
@@ -12,6 +12,7 @@ import {
   UserRoundPlus as UserRoundPlusIcon,
   UsersRound as UsersRoundIcon,
   X as CloseIcon,
+  LogOut as LogOutIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -232,21 +233,24 @@ export default function HeaderUserSection() {
             <p className="text-base text-gray-700">김스터디</p>
             {isUserMenuOpen && (
               <div
-                className={`absolute top-12 right-0 z-[${Z_INDEX.DROPDOWN}] w-48 rounded-lg border border-gray-200 bg-white py-2`}
+                className={`absolute top-12 right-0 z-[${Z_INDEX.DROPDOWN}] flex w-48 flex-col divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white py-2 shadow-lg`}
               >
                 <PageLink
                   pageLinkInnerText="마이페이지"
                   variant="ghost"
                   link="/profile"
-                  className="text-sm"
+                  className="text-sm text-gray-700"
                   fontWeight="normal"
+                  icon={UserRoundIcon}
                 />
                 <PageLink
                   pageLinkInnerText="로그아웃"
                   variant="ghost"
                   link="/logout"
-                  className="text-sm"
+                  iconClassName="rotate-180 stroke-"
+                  className="text-sm text-gray-700"
                   fontWeight="normal"
+                  icon={LogOutIcon}
                 />
               </div>
             )}


### PR DESCRIPTION
## 📌 개요
- HeaderUserSection 에서 마이페이지와 로그아웃 할수 있는 ui 구현

## 🔧 작업 내용

- [ ] divide-y, divide-gray-100 등 Tailwind 유틸로 드롭다운 메뉴 구분선 처리
- [ ] 마이페이지/로그아웃 등 메뉴 아이템의 아이콘-텍스트 간격, 폰트, 컬러 등 피그마와 맞춤

## 📎 관련 이슈
closes #87 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

