### PR TITLE
refactor: 채팅 컴포넌트 구조 개선(#96)

### DIFF
--- a/src/components/chat/ChatItem.tsx
+++ b/src/components/chat/ChatItem.tsx
@@ -1,0 +1,37 @@
+import type { Chat } from '@src/types/chat'
+
+interface ChatItemProps extends Chat {
+  openChatRoom: (chatData: Chat) => void
+}
+
+export default function ChatItem({ openChatRoom, ...data }: ChatItemProps) {
+  return (
+    <div
+      className="flex cursor-pointer flex-col gap-1 p-3"
+      onClick={() => openChatRoom(data)}
+    >
+      <div className="flex justify-between">
+        <h4 className="text-sm text-gray-900">{data.title}</h4>
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500">{data.date}</span>
+          {data.unreadCount && (
+            <div className="bg-danger-500 flex size-5 items-center justify-center rounded-full">
+              <p className="text-xs font-medium text-white">
+                {data.unreadCount}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="text-xs text-gray-600">
+          {data.lastMessage.sender}:
+        </span>
+        <p className="line-clamp-1 flex-1 text-xs text-gray-600">
+          {data.lastMessage.content}
+        </p>
+      </div>
+      <p className="text-xs text-gray-400">수정일시: {data.modifiedAt}</p>
+    </div>
+  )
+}

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -1,5 +1,6 @@
 import chatData from '@mock/chatData'
 import type { Chat } from '@src/types/chat'
+import ChatItem from './ChatItem'
 
 interface ChatListProps {
   openChatRoom: (chatData: Chat) => void
@@ -9,34 +10,7 @@ export default function ChatList({ openChatRoom }: ChatListProps) {
   return (
     <div className="flex max-h-[310px] w-[318px] flex-col divide-y divide-gray-200 overflow-y-auto">
       {chatData.map((data) => (
-        <div
-          key={data.id}
-          className="flex cursor-pointer flex-col gap-1 p-3"
-          onClick={() => openChatRoom(data)}
-        >
-          <div className="flex justify-between">
-            <h4 className="text-sm text-gray-900">{data.title}</h4>
-            <div className="flex items-center gap-1">
-              <span className="text-xs text-gray-500">{data.date}</span>
-              {data.unreadCount && (
-                <div className="bg-danger-500 flex size-5 items-center justify-center rounded-full">
-                  <p className="text-xs font-medium text-white">
-                    {data.unreadCount}
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-          <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-600">
-              {data.lastMessage.sender}:
-            </span>
-            <p className="line-clamp-1 flex-1 text-xs text-gray-600">
-              {data.lastMessage.content}
-            </p>
-          </div>
-          <p className="text-xs text-gray-400">수정일시: {data.modifiedAt}</p>
-        </div>
+        <ChatItem key={data.id} openChatRoom={openChatRoom} {...data} />
       ))}
     </div>
   )

--- a/src/components/chat/Chatting.tsx
+++ b/src/components/chat/Chatting.tsx
@@ -31,8 +31,10 @@ export default function Chatting({ toggleChat }: ChatProps) {
 
   const getOnlineCount = () => {
     if (!selectedChatRoom) return 0
-    return selectedChatRoom.participants.filter((p) => p.status === 'online')
-      .length
+    const onlineCount = selectedChatRoom.participants.filter(
+      (p) => p.status === 'online'
+    )
+    return onlineCount.length
   }
 
   const renderListView = () => (


### PR DESCRIPTION
## 📌 개요
- 채팅 컴포넌트 구조 개선

## 🔧 작업 내용

- [ ] ChatList 에서 ChatItem 컴포넌트화
- [ ] Chatting 에서 변수 가독성 향상
- [ ] Chatting, ChatList, ChatItem 등 채팅 관련 컴포넌트의 props와 내부 로직 정리

## 📎 관련 이슈

closes #96 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항


