### PR TITLE
feat: 전역 폰트 색상과 백그라운드 배경색 설정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,6 +8,14 @@
 /* 폰트(base 레이어로 직접 삽입) */
 @import './styles/fonts.css' layer(base);
 
+/* 전역 색상 설정 */
+@layer base {
+  body {
+    @apply text-gray-800;
+    @apply bg-gray-50;
+  }
+}
+
 /* RecruitmentManage 공통 css */
 @layer components {
   .rec-manage-section {

--- a/src/components/commons/JobPostCard.tsx
+++ b/src/components/commons/JobPostCard.tsx
@@ -51,9 +51,7 @@ export default function JobPostCard({
         <div className="flex w-full flex-col">
           {/* 제목과 조회수/댓글 + (옵션) 편집 버튼 */}
           <div className="flex w-full justify-between pb-3">
-            <p className="line-clamp-2 text-lg font-semibold text-gray-900">
-              {title}
-            </p>
+            <p className="line-clamp-2 text-lg font-semibold">{title}</p>
 
             <div className="ml-2 flex items-start gap-2">
               <div className="flex items-center gap-1">

--- a/src/components/commons/header/Header.tsx
+++ b/src/components/commons/header/Header.tsx
@@ -8,11 +8,11 @@ export default function Header() {
   return (
     <header
       className={cn(
-        'sticky top-0 flex h-16 w-full items-center justify-center border-b border-gray-200 px-20',
+        'sticky top-0 flex h-16 w-full items-center justify-center border-b border-gray-200 bg-white px-20',
         `z-[${Z_INDEX.HEADER}]`
       )}
     >
-      <div className="flex h-full w-full max-w-7xl justify-between bg-white px-8">
+      <div className="flex h-full w-full max-w-7xl justify-between px-8">
         <Logo />
         <Navigation />
       </div>

--- a/src/pages/RecruitmentManage.tsx
+++ b/src/pages/RecruitmentManage.tsx
@@ -5,7 +5,7 @@ import RecManageTotalCard from '@src/components/recruitment-manage/components/Re
 
 export default function RecruitmentManage() {
   return (
-    <div className="min-h-dvh w-full bg-[#F9FAFB]">
+    <div className="min-h-dvh w-full">
       <div className="mx-auto h-auto max-w-[1440px] px-20">
         {/* 내부 시작 */}
         <div className="max-w-7xl p-8">


### PR DESCRIPTION
## 📌 개요
전역으로 폰트 색상과 백그라운드 배경색을 설정했습니다.

## 🔧 작업 내용
- 전역 폰트 색상 및 백그라운드 배경색 설정

## 추가 작업
- 전역으로 설정한 부분 스타일 코드 삭제
- 헤더 백그라운드 수정

## 스크린샷 
<img width="1416" height="449" alt="image" src="https://github.com/user-attachments/assets/1b7b1225-91a2-4203-918c-b3dbe279888b" />

## 📎 관련 이슈
closes #110
