### PR TITLE
refactor: Badge 컴포넌트 리팩토링 

### DIFF
--- a/src/components/commons/Badge.tsx
+++ b/src/components/commons/Badge.tsx
@@ -1,19 +1,22 @@
 import { cn } from '@utils/cn'
+import type { ReactNode } from 'react'
 interface BadgeProps {
+  children?: ReactNode
   badgeTitle: string
-  sideClass?: string
+  className?: string
 }
 
-function Badge({ badgeTitle, sideClass }: BadgeProps) {
+function Badge({ children, badgeTitle, className }: BadgeProps) {
+  const content = children ?? badgeTitle
   return (
-    <p
+    <span
       className={cn(
         'flex w-fit items-center justify-center rounded px-2 py-1 text-xs',
-        sideClass
+        className
       )}
     >
-      {badgeTitle}
-    </p>
+      {content}
+    </span>
   )
 }
 

--- a/src/components/commons/JobPostCard.tsx
+++ b/src/components/commons/JobPostCard.tsx
@@ -119,7 +119,7 @@ export default function JobPostCard({
               <Badge
                 badgeTitle={tag}
                 key={tagIndex}
-                sideClass="bg-primary-100 text-primary-800"
+                className="bg-primary-100 text-primary-800"
               />
             ))}
           </div>

--- a/src/components/commons/StatusBadge.tsx
+++ b/src/components/commons/StatusBadge.tsx
@@ -10,5 +10,5 @@ const STATUS_MAP: Record<Status, { text: string; cls: string }> = {
 
 export default function StatusBadge({ status }: { status: Status }) {
   const parsedStatus = STATUS_MAP[status]
-  return <Badge badgeTitle={parsedStatus.text} sideClass={parsedStatus.cls} />
+  return <Badge badgeTitle={parsedStatus.text} className={parsedStatus.cls} />
 }

--- a/src/components/course/CourseCard.tsx
+++ b/src/components/course/CourseCard.tsx
@@ -33,11 +33,11 @@ function CourseCard({
         <div className="h-full w-full bg-cover bg-center bg-no-repeat" />
         <div className="absolute top-3 right-2 left-2 flex justify-between">
           <div className="flex flex-col items-start gap-4">
-            <Badge badgeTitle="Udemy" sideClass="bg-primary-500 text-white" />
+            <Badge badgeTitle="Udemy" className="bg-primary-500 text-white" />
             {isDiscounted && (
               <Badge
                 badgeTitle={`${discountPercentage}% 할인`}
-                sideClass="bg-danger-500 text-white"
+                className="bg-danger-500 text-white"
               />
             )}
           </div>
@@ -45,7 +45,7 @@ function CourseCard({
       </div>
       <div className="flex flex-grow flex-col p-5">
         <div className="pb-3">
-          <Badge badgeTitle="클라우드" sideClass="bg-gray-100 text-gray-700" />
+          <Badge badgeTitle="클라우드" className="bg-gray-100 text-gray-700" />
           <p className="line-clamp-2 pt-2 pb-1 text-lg leading-7 font-semibold text-gray-900">
             {cardTitle}
           </p>

--- a/src/components/recruitment-manage/components/ApplicantCard.tsx
+++ b/src/components/recruitment-manage/components/ApplicantCard.tsx
@@ -88,7 +88,7 @@ export default memo(function ApplicantCard({ data, onClick }: Props) {
         <InfoRow
           label="스터디 경험"
           direction="row"
-          badge={<Badge badgeTitle={expTitle} sideClass={badgeClass} />}
+          badge={<Badge badgeTitle={expTitle} className={badgeClass} />}
         />
       </div>
     </article>

--- a/src/pages/test-page/TestUIPage.tsx
+++ b/src/pages/test-page/TestUIPage.tsx
@@ -126,7 +126,7 @@ export default function TestUIPage() {
         />
 
         {/* 뱃지 */}
-        <Badge badgeTitle="거절됨" sideClass="bg-danger-100 text-danger-800" />
+        <Badge badgeTitle="거절됨" className="bg-danger-100 text-danger-800" />
       </div>
       <div className="flex gap-2">
         <Button


### PR DESCRIPTION
## 📌 개요

Badge 컴포넌트를 children 기반 구조로 리팩터링하여 텍스트 외에 버튼/아이콘 등도 담을 수 있도록 확장.
기존 badgeTitle prop은 유지하여 역호환 보장.
sideClass → className으로 변경.

## 🔧 작업 내용

- [x] Badge 컴포넌트를 children + badgeTitle 병행 지원 구조로 리팩터링
- [x] sideClass prop → className으로 변경
- [x] Badge 사용처 전반 수정 (sideClass → className)

## 📎 관련 이슈

closes #127 

## 💬 리뷰어 참고 사항

- const content = children ?? badgeTitle
- children이 있을 때는 children을 우선적으로 표시하고, 없을 때는 기존 badgeTitle을 fallback으로 사용
- 이렇게 하면 기존 코드 호환 + 확장 두 가지를 동시에 보장

기존처럼 badgeTitle만 넘기면 그대로 텍스트 뱃지로 사용 가능

`<Badge badgeTitle="예시뱃지" className="bg-yellow-500 text-white" />`

필요하다면 children 기반으로 버튼/아이콘 추가 가능

```
<Badge className="bg-yellow-500 text-white">
  예시 뱃지
  <button onClick={...} className="ml-1 text-xs hover:text-red-400">✕</button>
</Badge>
```
