### PR TITLE
feat: 스터디 구인 공고 업로드 컴포넌트 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^19.1.0",
         "react-datepicker": "^8.7.0",
         "react-dom": "^19.1.0",
+        "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.62.0",
         "react-markdown": "^10.1.0",
         "react-router": "^7.6.2",
@@ -3139,6 +3140,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4729,6 +4739,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5889,7 +5911,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6492,7 +6513,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7657,7 +7677,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8126,7 +8145,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8217,6 +8235,23 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.62.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
@@ -8237,7 +8272,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
-    "prepare": "git config core.hooksPath .husky || true"
+    "prepare": "husky install"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
@@ -22,6 +22,7 @@
     "react": "^19.1.0",
     "react-datepicker": "^8.7.0",
     "react-dom": "^19.1.0",
+    "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.62.0",
     "react-markdown": "^10.1.0",
     "react-router": "^7.6.2",

--- a/src/components/recruitment-create/FileUploadBox.tsx
+++ b/src/components/recruitment-create/FileUploadBox.tsx
@@ -1,0 +1,45 @@
+import { FileUp } from 'lucide-react'
+import DottedBox from './uploadbox-ui/DottedBox'
+import FileList from './uploadbox-ui/FileList'
+import useUploader from './uploadbox-ui/useUploader'
+
+export function FileUploadBox() {
+  const { files, state, getRootProps, getInputProps, removeAt } = useUploader({
+    accept: { '*/*': [] },
+    maxFiles: 3,
+    onError: (m) => alert(m),
+  })
+
+  return (
+    <DottedBox
+      state={state}
+      className="h-[282px] !p-0"
+      {...getRootProps({ role: 'button', tabIndex: 0 })}
+    >
+      <input {...getInputProps()} />
+      <div className="w-full p-6 sm:p-8">
+        <div className="text-center select-none">
+          <FileUp className="mx-auto mb-2 h-8 w-8 text-gray-500 opacity-70" />
+          <p className="text-sm font-medium text-gray-500">
+            파일을 드래그하거나 클릭하여 업로드
+          </p>
+          <p className="mt-1 text-xs text-gray-500">
+            최대 3개 파일, 각 5MB 이하
+          </p>
+        </div>
+
+        {files.length > 0 && (
+          <div className="mx-auto mt-4 max-h-48 overflow-y-auto">
+            <FileList
+              files={files}
+              onRemove={removeAt}
+              showPreview
+              thumbSize={24}
+              dense
+            />
+          </div>
+        )}
+      </div>
+    </DottedBox>
+  )
+}

--- a/src/components/recruitment-create/ImageUploadBox.tsx
+++ b/src/components/recruitment-create/ImageUploadBox.tsx
@@ -1,0 +1,79 @@
+import { Plus as PlusIcon, ImagePlus as ImagePlusIcon } from 'lucide-react'
+import DottedBox from './uploadbox-ui/DottedBox'
+import useUploader, { type Uploaded } from './uploadbox-ui/useUploader'
+
+export function ImageUploadBox() {
+  const { files, state, getRootProps, getInputProps, removeAt, open } =
+    useUploader({
+      accept: { 'image/*': ['.jpg', '.jpeg', '.png'] },
+      maxFiles: 5,
+      multiple: true,
+      createPreview: true,
+      onError: (m) => alert(m),
+    })
+
+  const MAX = 5
+
+  return (
+    <DottedBox
+      state={state}
+      className="min-h-[132px] !p-0"
+      {...getRootProps({ role: 'button', tabIndex: 0 })}
+    >
+      <input {...getInputProps()} />
+
+      <div className="w-full p-6 sm:p-8">
+        {files.length === 0 && (
+          <div className="text-center select-none">
+            <ImagePlusIcon className="mx-auto mb-2 h-8 w-8 text-gray-500 opacity-70" />
+            <p className="text-sm font-medium text-gray-500">
+              클릭하여 이미지 업로드
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              JPG, PNG (최대 5MB, 최대 5장)
+            </p>
+          </div>
+        )}
+
+        {files.length > 0 && (
+          <div
+            className="mt-2"
+            onClick={(e) => e.stopPropagation()} // 썸네일 클릭이 드롭존 열기로 버블링되는 것 방지
+          >
+            <ul className="grid grid-cols-3 gap-3 sm:grid-cols-5">
+              {files.map((f: Uploaded, i) => (
+                <li key={`${f.name}-${i}`} className="relative">
+                  <img
+                    src={f.preview}
+                    alt={f.name}
+                    className="h-24 w-full rounded-lg object-cover"
+                    onLoad={() => f.preview && URL.revokeObjectURL(f.preview)}
+                    onClick={() => removeAt(i)}
+                  />
+                </li>
+              ))}
+
+              {files.length < MAX && (
+                <li>
+                  <button
+                    type="button"
+                    className="grid h-24 w-full place-items-center rounded-lg border border-dashed border-gray-300 hover:bg-gray-50"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      open?.()
+                    }}
+                  >
+                    <PlusIcon className="h-6 w-6 text-gray-500" />
+                    <span className="mt-0 text-xs text-gray-500">
+                      {files.length}/{MAX}
+                    </span>
+                  </button>
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+      </div>
+    </DottedBox>
+  )
+}

--- a/src/components/recruitment-create/uploadbox-ui/DottedBox.tsx
+++ b/src/components/recruitment-create/uploadbox-ui/DottedBox.tsx
@@ -1,0 +1,46 @@
+import { cva } from 'class-variance-authority'
+import type { HTMLAttributes, ReactNode } from 'react'
+
+const BOX = cva(
+  'rounded-xl border-2 border-dashed p-6 sm:p-8 grid place-items-center transition-colors',
+  {
+    variants: {
+      state: {
+        idle: 'border-gray-300 bg-white',
+        active: 'border-blue-500 bg-blue-50',
+        reject: 'border-red-400 bg-red-50',
+        disabled: 'border-gray-200 bg-gray-50 opacity-60',
+      },
+      size: {
+        sm: 'min-h-28',
+        md: 'min-h-36',
+        lg: 'min-h-40',
+      },
+      full: { true: 'w-full', false: 'w-[520px]' },
+    },
+    defaultVariants: { state: 'idle', size: 'md', full: true },
+  }
+)
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  state?: 'idle' | 'active' | 'reject' | 'disabled'
+  size?: 'sm' | 'md' | 'lg'
+  full?: boolean
+  children?: ReactNode
+}
+
+// Dot로 된 박스만을 출력하는 Component
+export default function DottedBox({
+  state = 'idle',
+  size = 'md',
+  full = true,
+  className,
+  children,
+  ...rest
+}: Props) {
+  return (
+    <div className={BOX({ state, size, full, className })} {...rest}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/recruitment-create/uploadbox-ui/FileList.tsx
+++ b/src/components/recruitment-create/uploadbox-ui/FileList.tsx
@@ -1,0 +1,94 @@
+import { FileText as FileTextIcon, X as XIcon } from 'lucide-react'
+
+interface Props {
+  files: (File & { preview?: string })[]
+  onRemove?: (i: number) => void
+  showSize?: boolean
+  showPreview?: boolean
+  thumbSize?: number
+  dense?: boolean
+  className?: string
+}
+
+export default function FileList({
+  files,
+  onRemove,
+  showSize = true,
+  showPreview = false,
+  thumbSize = 32,
+  dense = false,
+  className,
+}: Props) {
+  if (!files.length) return null
+
+  const fmt = (n: number) => (n / 1024 / 1024).toFixed(2) + 'MB'
+
+  return (
+    <div
+      className={`space-y-2 ${className ?? ''}`}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <p className="text-sm text-gray-600">업로드된 파일:</p>
+
+      <ul className="divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white">
+        {files.map((f, i) => {
+          const isImg = f.type?.startsWith('image/')
+          return (
+            <li
+              key={`${f.name}-${i}`}
+              className={`flex items-center justify-between px-3 ${dense ? 'py-1.5' : 'py-2'}`}
+            >
+              <div className="flex items-center gap-3">
+                {showPreview && isImg && f.preview ? (
+                  <img
+                    src={f.preview}
+                    alt={f.name}
+                    className="shrink-0 rounded object-cover"
+                    style={{
+                      width: thumbSize,
+                      height: thumbSize,
+                      minWidth: thumbSize,
+                      minHeight: thumbSize,
+                    }}
+                    onLoad={() => URL.revokeObjectURL(f.preview!)}
+                  />
+                ) : (
+                  <FileTextIcon
+                    className="shrink-0 text-gray-500"
+                    style={{
+                      width: Math.max(thumbSize - 8, 16),
+                      height: Math.max(thumbSize - 8, 16),
+                    }}
+                    aria-hidden
+                  />
+                )}
+
+                <span className="max-w-[520px] truncate text-sm font-medium text-gray-800">
+                  {f.name}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2 text-gray-500">
+                {showSize && <span className="text-xs">{fmt(f.size)}</span>}
+                {!!onRemove && (
+                  <button
+                    type="button"
+                    className="rounded-md p-1 hover:bg-gray-100"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onRemove(i)
+                    }}
+                    aria-label={`${f.name} 제거`}
+                  >
+                    <XIcon className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/recruitment-create/uploadbox-ui/useUploader.ts
+++ b/src/components/recruitment-create/uploadbox-ui/useUploader.ts
@@ -1,0 +1,98 @@
+import { useCallback, useState } from 'react'
+import { useDropzone, type Accept, type FileRejection } from 'react-dropzone'
+
+export type Uploaded = File & { preview?: string }
+
+export interface useUploaderOptions {
+  accept?: Accept
+  maxFiles?: number
+  maxSize?: number
+  multiple?: boolean
+  createPreview?: boolean // 아직 생성되지 않은 경우 미리보기가 안보이도록 세팅
+  disabled?: boolean
+  onError?: (msg: string) => void
+}
+
+export default function useUploader({
+  accept,
+  maxFiles = 3,
+  maxSize = 5 * 1024 * 1024,
+  multiple = true,
+  createPreview = false,
+  disabled,
+  onError,
+}: useUploaderOptions) {
+  const [files, setFiles] = useState<Uploaded[]>([])
+
+  const onDrop = useCallback(
+    (accepted: File[], rejections: FileRejection[]) => {
+      // 기존 값도 포함해서 체크
+      if (rejections.length) {
+        const err = rejections[0]?.errors?.[0]
+        const msg =
+          err?.code === 'file-too-large'
+            ? `파일 용량 초과 (최대 ${(maxSize / 1024 / 1024).toFixed(0)}MB)`
+            : err?.code === 'too-many-files'
+              ? `최대 ${maxFiles}개까지 업로드 가능`
+              : '허용되지 않는 형식입니다.'
+        onError?.(msg)
+      }
+      if (!accepted.length) return
+
+      // 1) 중복 제거 (이름+크기 기준)
+      const deduped = accepted.filter(
+        (file) =>
+          !files.some((e) => e.name === file.name && e.size === file.size)
+      )
+
+      // 2) 총 개수 제한
+      const remain = Math.max(0, maxFiles - files.length)
+      const sliced = multiple ? deduped.slice(0, remain) : deduped.slice(0, 1)
+
+      if (!sliced.length) {
+        onError?.(`최대 ${maxFiles}개까지 업로드 가능`)
+        return
+      }
+
+      const withPreview: Uploaded[] = sliced.map((f) =>
+        Object.assign(f, {
+          preview: createPreview ? URL.createObjectURL(f) : undefined,
+        })
+      )
+      const next = multiple ? [...files, ...withPreview] : [withPreview[0]]
+      setFiles(next)
+    },
+    [files, maxFiles, maxSize, multiple, createPreview, onError]
+  )
+
+  // 라이브러리에서 필요한 부분만 꺼내 쓰기
+  const dz = useDropzone({
+    onDrop,
+    accept,
+    maxFiles,
+    maxSize,
+    multiple,
+    disabled,
+  })
+
+  const state: 'idle' | 'active' | 'reject' | 'disabled' = disabled
+    ? 'disabled'
+    : dz.isDragReject
+      ? 'reject'
+      : dz.isDragActive || dz.isFocused
+        ? 'active'
+        : 'idle'
+
+  const removeAt = (i: number) =>
+    setFiles((prev) => prev.filter((_, idx) => idx !== i))
+
+  return {
+    files,
+    setFiles,
+    removeAt,
+    state,
+    getRootProps: dz.getRootProps,
+    getInputProps: dz.getInputProps,
+    open: dz.open,
+  }
+}

--- a/src/components/recruitment-create/uploadbox-ui/useUploader.ts
+++ b/src/components/recruitment-create/uploadbox-ui/useUploader.ts
@@ -1,14 +1,14 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useDropzone, type Accept, type FileRejection } from 'react-dropzone'
 
 export type Uploaded = File & { preview?: string }
 
-export interface useUploaderOptions {
+export interface UseUploaderOptions {
   accept?: Accept
-  maxFiles?: number
+  maxFiles?: number // 합계 제한
   maxSize?: number
   multiple?: boolean
-  createPreview?: boolean // 아직 생성되지 않은 경우 미리보기가 안보이도록 세팅
+  createPreview?: boolean // 이미지 미리보기 URL 생성 여부
   disabled?: boolean
   onError?: (msg: string) => void
 }
@@ -21,55 +21,66 @@ export default function useUploader({
   createPreview = false,
   disabled,
   onError,
-}: useUploaderOptions) {
+}: UseUploaderOptions) {
   const [files, setFiles] = useState<Uploaded[]>([])
+
+  // 최신 files 참조용 ref
+  const filesRef = useRef<Uploaded[]>([])
+  useEffect(() => {
+    filesRef.current = files
+  }, [files])
 
   const onDrop = useCallback(
     (accepted: File[], rejections: FileRejection[]) => {
-      // 기존 값도 포함해서 체크
+      // 용량/형식 오류 안내
       if (rejections.length) {
         const err = rejections[0]?.errors?.[0]
-        const msg =
-          err?.code === 'file-too-large'
-            ? `파일 용량 초과 (최대 ${(maxSize / 1024 / 1024).toFixed(0)}MB)`
-            : err?.code === 'too-many-files'
-              ? `최대 ${maxFiles}개까지 업로드 가능`
-              : '허용되지 않는 형식입니다.'
-        onError?.(msg)
+        if (err?.code === 'file-too-large') {
+          onError?.(
+            `파일 용량 초과 (최대 ${(maxSize / 1024 / 1024).toFixed(0)}MB)`
+          )
+        } else if (err?.message) {
+          onError?.(err.message)
+        }
       }
       if (!accepted.length) return
 
-      // 1) 중복 제거 (이름+크기 기준)
-      const deduped = accepted.filter(
-        (file) =>
-          !files.some((e) => e.name === file.name && e.size === file.size)
-      )
+      const current = filesRef.current
 
-      // 2) 총 개수 제한
-      const remain = Math.max(0, maxFiles - files.length)
-      const sliced = multiple ? deduped.slice(0, remain) : deduped.slice(0, 1)
+      const remain = Math.max(0, maxFiles - current.length)
+      const allowed = multiple
+        ? accepted.slice(0, remain)
+        : accepted.slice(0, 1)
+      const overflow = accepted.length - allowed.length
 
-      if (!sliced.length) {
+      if (!allowed.length) {
         onError?.(`최대 ${maxFiles}개까지 업로드 가능`)
         return
       }
+      if (overflow > 0) {
+        onError?.(
+          `최대 ${maxFiles}개까지 업로드 가능 (추가 ${overflow}개는 제외됨)`
+        )
+      }
 
-      const withPreview: Uploaded[] = sliced.map((f) =>
+      // preview 부착
+      const withPreview: Uploaded[] = allowed.map((f) =>
         Object.assign(f, {
           preview: createPreview ? URL.createObjectURL(f) : undefined,
         })
       )
-      const next = multiple ? [...files, ...withPreview] : [withPreview[0]]
-      setFiles(next)
+
+      setFiles((prev) =>
+        multiple ? [...prev, ...withPreview] : [withPreview[0]]
+      )
     },
-    [files, maxFiles, maxSize, multiple, createPreview, onError]
+    [maxFiles, maxSize, multiple, createPreview, onError]
   )
 
-  // 라이브러리에서 필요한 부분만 꺼내 쓰기
+  // Dropzone 설정 (maxFiles는 주지 않음: 합계 제한은 우리가 관리)
   const dz = useDropzone({
     onDrop,
     accept,
-    maxFiles,
     maxSize,
     multiple,
     disabled,
@@ -83,13 +94,35 @@ export default function useUploader({
         ? 'active'
         : 'idle'
 
+  // 삭제 시 preview URL 정리
   const removeAt = (i: number) =>
-    setFiles((prev) => prev.filter((_, idx) => idx !== i))
+    setFiles((prev) => {
+      const target = prev[i]
+      if (target?.preview) URL.revokeObjectURL(target.preview)
+      return prev.filter((_, idx) => idx !== i)
+    })
+
+  // 전체 초기화
+  const reset = () =>
+    setFiles((prev) => {
+      prev.forEach((f) => f.preview && URL.revokeObjectURL(f.preview))
+      return []
+    })
+
+  // 언마운트 시 preview URL 정리
+  useEffect(() => {
+    return () => {
+      filesRef.current.forEach(
+        (f) => f.preview && URL.revokeObjectURL(f.preview)
+      )
+    }
+  }, [])
 
   return {
     files,
     setFiles,
     removeAt,
+    reset,
     state,
     getRootProps: dz.getRootProps,
     getInputProps: dz.getInputProps,

--- a/src/pages/RecruitmentCreate.tsx
+++ b/src/pages/RecruitmentCreate.tsx
@@ -1,3 +1,5 @@
+import { FileUploadBox } from '@src/components/recruitment-create/FileUploadBox'
+import { ImageUploadBox } from '@src/components/recruitment-create/ImageUploadBox'
 import StudyIntroMarkdown from '@src/components/recruitment-create/StudyIntroMarkdown'
 import { useState } from 'react'
 
@@ -6,6 +8,12 @@ export default function RecruitmentCreate() {
   return (
     <div className="p-10">
       <StudyIntroMarkdown value={intro} onChange={setIntro} />
+      <div className="mt-20">
+        <ImageUploadBox />
+      </div>
+      <div className="mt-20">
+        <FileUploadBox />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 📌 개요

- 스터디 그룹 대표 이미지 & 참고 파일 업로드 & 태그 검색에 사용할 컴포넌트 기능 구

## 🔧 작업 내용

- [ ] `DottedBox`: 도트 박스 외각에 UI를 구현하는 컴포넌트
- [ ] `FileList.tsx`: 업로드 된 파일을 나타내는 리스트
- [ ] `useUploader`: 파일(이미지, 파일등)을 업로드할 때 체크하는 hook
- [ ] `FileUploadBox`: 파일 업로드 component
- [ ] `ImageUploadBox`: 이미지 업로드 component 

## 📎 관련 이슈

closes #99 

## 📸 스크린샷
### 1. 이미지 업로드
![image_uploade](https://github.com/user-attachments/assets/7d608e27-58d8-46b2-a2d0-436b16453993)

### 2. 파일 업로드
![file_uplode](https://github.com/user-attachments/assets/6880e89f-2ff9-4bc0-b070-0fe65580b59b)


## 💬 리뷰어 참고 사항

- 업로드 예외 사항을 좀 더 추가할지에 대한 점
