### PR TITLE
feat: 메인 레이아웃에 채팅 버튼 추가

### DIFF
--- a/src/components/commons/chat/Chatting.tsx
+++ b/src/components/commons/chat/Chatting.tsx
@@ -54,7 +54,7 @@ export default function Chatting({ toggleChat }: ChatProps) {
           onClose={toggleChat}
         />
         <ParticipantsList participants={selectedChatRoom.participants} />
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1">
           <MessageList messages={selectedChatRoom.messages} />
         </div>
         <MessageInput onSend={sendMessage} />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,10 +1,12 @@
 import Header from '@components/commons/header/Header'
+import ChatFloatButton from '@src/components/commons/chat/ChatFloatButton'
 import { Outlet } from 'react-router-dom'
 
 export default function MainLayout() {
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
+      <ChatFloatButton />
       <main className="w-full flex-1">
         <Outlet />
       </main>


### PR DESCRIPTION
## 📌 개요
메인 레이아웃에 채팅 버튼을 추가했습니다.
이제 모든 페이지에서 채팅 버튼이 보이게 됩니다.

## 🔧추가 작업
- 채팅에 스크롤바가 2개가 보이는 버그 수정(수정 전 이미지 첨부)
<img width="307" height="371" alt="image" src="https://github.com/user-attachments/assets/62202b19-483e-4d9b-b162-d503ee20ae5a" />

## 📎 관련 이슈
closes #136

## 📸 스크린샷
<img width="1314" height="499" alt="image" src="https://github.com/user-attachments/assets/b9a1f547-dd72-4b03-bde4-5901acd47384" />
