### PR TITLE
fix: <Link>tag 대신에 <button>tag로 수정

### DIFF
--- a/src/components/commons/JobPostCard.tsx
+++ b/src/components/commons/JobPostCard.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react'
 import Badge from './Badge'
 import Icon from './Icon'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { ROUTES } from '@src/constants/routes'
 import type { JobPost } from '@src/types/jobPosts'
 
@@ -25,6 +25,8 @@ export default function JobPostCard({
   onClickApply,
   editTo,
 }: JobPostCardProps) {
+  const NAVIGATE = useNavigate()
+
   if (!post) return null
 
   const {
@@ -69,17 +71,21 @@ export default function JobPostCard({
                   className="stroke-gray-500"
                 />
                 <p className="text-sm text-gray-500">{commentCount}</p>
+                {editTo && (
+                  <button
+                    type="button"
+                    aria-label="스터디 공고 수정"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      NAVIGATE(editTo)
+                    }}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded-full hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                  >
+                    <PencilIcon size={16} className="stroke-gray-500" />
+                  </button>
+                )}
               </div>
-
-              {editTo && (
-                <Link
-                  to={editTo}
-                  className="inline-flex h-7 w-7 items-center justify-center rounded-full hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <PencilIcon size={16} className="stroke-gray-500" />
-                </Link>
-              )}
             </div>
           </div>
 


### PR DESCRIPTION
## 📌 개요

- `JobPostCard`에 수정하기 버튼에 <Link> 태그를 중첩으로 사용하여 생긴 문제를 대신에 <button>으로 수정하여 이를 반영함.

## 🔧 작업 내용

- [ ] `JobPostCard`: `<Link>...</Link>` 에서 `<button>...</button>` 형식으로 수정

## 📎 관련 이슈

closes #150 

## 📸 스크린샷
<img width="1910" height="937" alt="image" src="https://github.com/user-attachments/assets/f15efb19-09c7-4431-901b-61b3e03ce111" />


## 💬 리뷰어 참고 사항

- 링크 방식 수정했습니다.
