### PR TITLE
feat: 공고 작성 페이지 태그 관련 컴포넌트 구현

### DIFF
--- a/src/components/commons/EmptyState.tsx
+++ b/src/components/commons/EmptyState.tsx
@@ -1,5 +1,6 @@
 import Icon from '@src/components/commons/Icon'
 import { EMPTY_STATE_ICONS } from '@src/constants/ui'
+import { cn } from '@src/utils/cn'
 import type { LucideIcon } from 'lucide-react'
 
 interface EmptyStateProps {
@@ -7,8 +8,13 @@ interface EmptyStateProps {
   description?: string
   iconType?: keyof typeof EMPTY_STATE_ICONS
   customIcon?: LucideIcon
-  iconClassName?: string
-  iconContainerClassName?: string
+  iconSize?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number //아이콘 크기
+  size?: 'sm' | 'md' | 'lg' //EmptyState 전체 크기 프리셋
+  iconClassName?: string //아이콘 자체에 추가할 className
+  iconContainerClassName?: string // 아이콘 컨테이너 div에 추가할 className 간격, 정렬
+  wrapperClassName?: string //최상위 wrapper div에 추가할 className
+  titleClassName?: string // 제목 텍스트에 추가할 className
+  descClassName?: string // 설명 텍스트에 추가할 className
 }
 
 export function EmptyState({
@@ -16,23 +22,56 @@ export function EmptyState({
   description = '다른 검색어나 필터를 시도해보세요.',
   iconType = 'SEARCH_RESULTS',
   customIcon,
+  iconSize = 'lg',
+  size = 'lg',
   iconClassName = 'stroke-gray-400',
-  iconContainerClassName,
+  iconContainerClassName = '',
+  wrapperClassName = '',
+  titleClassName = '',
+  descClassName = '',
 }: EmptyStateProps) {
   const IconComponent = customIcon || EMPTY_STATE_ICONS[iconType]
+  // props.size(sm | md | lg)에 따라 EmptyState의 레이아웃과 폰트 스타일을 일관되게 적용하기 위해 사용
+  const SIZES = {
+    sm: { wrapper: 'py-0', title: 'text-md font-semibold', desc: 'text-md' },
+    md: { wrapper: 'py-10', title: 'text-lg font-bold', desc: 'text-lg' },
+    lg: {
+      wrapper: 'py-20',
+      title: 'text-xl font-bold',
+      desc: 'text-lg',
+    },
+  } as const
+
+  const sizeStyles = SIZES[size] ?? SIZES.lg //지정 안 됐거나 유효하지 않은 값이면 lg를 기본값으로 사용
 
   return (
-    <div className="flex items-center justify-center py-20">
+    <div
+      className={cn(
+        'flex items-center justify-center',
+        sizeStyles.wrapper,
+        wrapperClassName
+      )}
+    >
       <div className="flex flex-col items-center justify-center text-center">
-        <div className={`mb-6 flex justify-center ${iconContainerClassName}`}>
+        <div className={cn('flex justify-center', iconContainerClassName)}>
           <Icon
             icon={IconComponent}
-            size="lg"
-            className={`h-16 w-16 ${iconClassName}`}
+            size={iconSize}
+            className={iconClassName}
           />
         </div>
-        <h4 className="pb-2 text-xl font-semibold text-gray-900">{title}</h4>
-        <p className="text-base text-gray-500">{description}</p>
+        <h4
+          className={cn(
+            'pb-2 font-semibold text-gray-900',
+            sizeStyles.title,
+            titleClassName
+          )}
+        >
+          {title}
+        </h4>
+        <p className={cn('text-gray-500', sizeStyles.desc, descClassName)}>
+          {description}
+        </p>
       </div>
     </div>
   )

--- a/src/components/recruitment-create/tag-ui/TagBox.tsx
+++ b/src/components/recruitment-create/tag-ui/TagBox.tsx
@@ -1,0 +1,104 @@
+import Button from '@src/components/commons/button/Button'
+import { EmptyState } from '@src/components/commons/EmptyState'
+import SelectedTagList from '@src/components/commons/tag/SelectedTagList'
+import { cn } from '@src/utils/cn'
+import { Plus } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+
+export interface Tag {
+  id: number
+  name: string
+}
+
+export interface TagBoxProps {
+  value?: Tag[] // 선택 (선택)
+  onChange?: (next: Tag[]) => void // 변경 콜백 (선택)
+  max?: number // 기본 5
+  title?: string // 기본 '사용자 정의 태그'
+  onOpenSearch?: () => void // (옵션) 모달 연결
+}
+
+export default function TagBox({
+  value,
+  onChange,
+  max = 5,
+  title = '사용자 정의 태그',
+  onOpenSearch,
+}: TagBoxProps) {
+  const [inner, setInner] = useState<Tag[]>([
+    // 더미데이터
+    { id: 1, name: '초보자환영' },
+    { id: 2, name: '주말스터디' },
+    { id: 3, name: '프로젝트중심' },
+  ])
+
+  const tags = value ?? inner //현재 TagBox가 관리할 실제 태그 목록
+  const setTags = onChange ?? setInner //태그 목록을 변경
+  const countText = useMemo(() => `(${tags.length}/${max})`, [tags.length, max]) // 현재 태그 개수와 최대 개수를 문자열로 표시
+  const selectedIds = useMemo(() => tags.map((t) => String(t.id)), [tags]) // 현재 선택된 태그들의 id 목록
+
+  const options = useMemo(
+    () => tags.map((tag) => ({ id: String(tag.id), label: tag.name })),
+    [tags]
+  )
+
+  // 태그 삭제 처리
+  const removeById = useCallback(
+    (idStr: string) => {
+      const idNum = Number(idStr)
+      setTags(tags.filter((tag) => tag.id !== idNum))
+    },
+    [tags, setTags]
+  )
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start justify-between">
+        <span className="text-md font-medium text-gray-900">{title}</span>
+        <Button
+          size="base"
+          buttonInnerText="태그 검색"
+          icon={Plus}
+          iconSize="sm"
+          onClick={onOpenSearch} //모달연결
+        ></Button>
+      </div>
+      <div
+        className={cn(
+          'rounded-sm border-2 px-4 py-6',
+          tags.length === 0
+            ? 'border-dashed border-gray-300'
+            : 'border border-gray-300 bg-gray-100'
+        )}
+      >
+        <div
+          className={cn(
+            'flex flex-wrap items-center gap-3',
+            tags.length === 0 ? 'justify-center' : 'justify-start'
+          )}
+        >
+          {tags.length === 0 ? (
+            <EmptyState
+              title="선택된 태그가 없습니다."
+              iconType="TAG"
+              titleClassName="text-gray-500 pb-0"
+              description="태그 검색 버튼을 클릭해서 태그를 추가해 보세요"
+              descClassName="text-md"
+              iconSize="lg"
+              size="sm"
+            />
+          ) : (
+            <SelectedTagList
+              selectedIds={selectedIds}
+              options={options}
+              onRemove={removeById}
+            />
+          )}
+        </div>
+      </div>
+      <p className="text-xs text-gray-500">
+        태그는 최대 {max}개까지 선택할 수 있습니다 {countText}
+      </p>
+    </div>
+  )
+}

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -6,6 +6,7 @@ import {
   XCircle,
   Inbox as NoDataIcon,
   type LucideIcon,
+  Tag,
 } from 'lucide-react'
 
 // 페이지네이션 설정
@@ -134,6 +135,7 @@ export const EMPTY_MESSAGES = {
   SEARCH_RESULTS: '검색 결과가 없습니다.',
   NoData: '공고가 없습니다',
   FALLBACK: '데이터가 없습니다.',
+  TAG: '선택된 태그가 없습니다.',
 } as const
 
 export const EMPTY_STATE_ICONS: Record<
@@ -146,6 +148,7 @@ export const EMPTY_STATE_ICONS: Record<
   SEARCH_RESULTS: Search,
   NoData: NoDataIcon,
   FALLBACK: AlertCircle,
+  TAG: Tag,
 } as const
 
 // 에러 메시지와 아이콘

--- a/src/pages/RecruitmentCreate.tsx
+++ b/src/pages/RecruitmentCreate.tsx
@@ -1,6 +1,7 @@
 import { FileUploadBox } from '@src/components/recruitment-create/FileUploadBox'
 import { ImageUploadBox } from '@src/components/recruitment-create/ImageUploadBox'
 import StudyIntroMarkdown from '@src/components/recruitment-create/StudyIntroMarkdown'
+import TagBox from '@src/components/recruitment-create/tag-ui/TagBox'
 import { useState } from 'react'
 
 export default function RecruitmentCreate() {
@@ -13,6 +14,9 @@ export default function RecruitmentCreate() {
       </div>
       <div className="mt-20">
         <FileUploadBox />
+      </div>
+      <div className="mt-20">
+        <TagBox />
       </div>
     </div>
   )


### PR DESCRIPTION
## 📌 개요

- 공고 작성 페이지에 태그 선택 박스 UI(TagBox)를 추가했습니다.
- 태그가 없을 때 보여줄 EmptyState에 사이즈 옵션을 확장하여, 인라인 컨텍스트에서도 자연스럽게 사용할 수 있도록 수정

## 🔧 작업 내용

- [x] TagBox 컴포넌트 추가
- 태그 목록 표시 / 삭제 기능
- 태그 없을 때 EmptyState 표시
- 최대 개수 표시 
- [x] EmptyState 컴포넌트 확장
- size / iconSize / className 프롭 추가
- 작은 영역에서도 활용 가능

## 📎 관련 이슈

closes #145 

## 📸 스크린샷 (선택)


https://github.com/user-attachments/assets/1f10331c-5d6c-426a-9569-2cba935acf69


## 💬 리뷰어 참고 사항

- TagBox는 현재 더미 데이터 기반으로만 동작. 추후 모달/검색 API 연동 .
- EmptyState는 기본값(lg) 유지로 기존 사용처에 영향이 없도록 수정.
- 다음 작업: 태그 검색 버튼 -> 모달 연동 예정
