### PR TITLE
feat: Pagination 컴포넌트 추가

### DIFF
--- a/src/components/commons/pagination/Pagination.tsx
+++ b/src/components/commons/pagination/Pagination.tsx
@@ -1,3 +1,73 @@
-export default function Pagination() {
-  return
+import { cn } from '@src/utils/cn'
+import Button from '../button/Button'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+
+interface PaginationProps {
+  page: number //현재페이지
+  totalCount: number //총 페이지 수
+  size?: number //페이지당 아이템 수 (기본 5)
+  onPageChange: (page: number) => void
+  className?: string
+}
+
+export default function Pagination({
+  page,
+  totalCount,
+  size = 5,
+  onPageChange,
+  className,
+}: PaginationProps) {
+  const totalPages = Math.ceil(totalCount / size)
+  const groupSize = 10
+  const currentGroup = Math.floor((page - 1) / groupSize) // 0부터 시작
+  const start = currentGroup * groupSize + 1
+  const end = Math.min(start + groupSize - 1, totalPages)
+
+  const pages = Array.from({ length: end - start + 1 }, (_, i) => start + i)
+
+  if (totalPages <= 1) return null // 페이지가 하나면 안보여줌
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center gap-2 text-xs',
+        className
+      )}
+    >
+      <Button
+        icon={ChevronLeftIcon}
+        iconSize="sm"
+        variant="secondary"
+        iconClassName="text-gray-500"
+        className="rounded-xl border border-gray-200"
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        aria-label="이전 페이지"
+      />
+      {pages.map((pageNum) => (
+        <Button
+          key={pageNum}
+          buttonInnerText={String(pageNum)}
+          size="base"
+          variant={pageNum === page ? 'primary' : 'secondary'}
+          onClick={() => onPageChange(pageNum)}
+          className={cn(
+            'h-10 w-10 rounded-xl p-0 tabular-nums',
+            pageNum === page ? '' : 'border border-gray-200'
+          )}
+          aria-current={pageNum === page ? 'page' : undefined}
+        />
+      ))}
+      <Button
+        icon={ChevronRightIcon}
+        iconSize="sm"
+        variant="secondary"
+        iconClassName="text-gray-500"
+        className="rounded-xl border border-gray-200"
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        aria-label="다음 페이지"
+      />
+    </div>
+  )
 }

--- a/src/components/commons/pagination/Pagination.tsx
+++ b/src/components/commons/pagination/Pagination.tsx
@@ -1,0 +1,3 @@
+export default function Pagination() {
+  return
+}

--- a/src/pages/test-page/TestUIPage.tsx
+++ b/src/pages/test-page/TestUIPage.tsx
@@ -16,6 +16,7 @@ import { useToast } from '@src/components/commons/toast'
 import TagCheckbox from '@src/components/commons/tag/TagCheckbox'
 import type { TagOption } from '@src/components/commons/tag/SelectedTagList'
 import SelectedTagList from '@src/components/commons/tag/SelectedTagList'
+import Pagination from '@src/components/commons/pagination/Pagination'
 
 export default function TestUIPage() {
   const [selectedCategory, setSelectedCategory] = useState('전체')
@@ -29,6 +30,11 @@ export default function TestUIPage() {
     { id: 't2', label: '주말스터디' },
     { id: 't3', label: '프로젝트중심' },
   ]
+
+  //페이지네이션 임시 변수
+  const [page, setPage] = useState(1)
+  const size = 5
+  const totalCount = 50 // 서버 응답에서 count로 받아옴
 
   const categories = [
     { id: 1, name: '전체' },
@@ -245,6 +251,13 @@ export default function TestUIPage() {
             />
           ))}
         </div>
+        {/* 페이지 네이션 테스트  */}
+        <Pagination
+          page={page}
+          totalCount={totalCount}
+          size={size}
+          onPageChange={setPage}
+        />
       </div>
     </>
   )


### PR DESCRIPTION
## 📌 개요

 공용 Pagination 컴포넌트를 추가
- 태그 검색 모달 등 리스트 UI에서 사용할 예정

## 🔧 작업 내용

- [x]  Pagination 컴포넌트 제작
- [x]  이전/다음 버튼
- [x]  페이지 번호 버튼 (10개 단위)

## 📎 관련 이슈

closes #157 

## 📸 스크린샷 (선택)

<img width="651" height="69" alt="image" src="https://github.com/user-attachments/assets/64b1ddd0-dde7-4379-8a88-83b3c496701c" />

