### PR TITLE
refactor: 캘린더와 마크다운 리팩토링 작업

### DIFF
--- a/src/components/commons/calendar/Calendar.style.css
+++ b/src/components/commons/calendar/Calendar.style.css
@@ -37,10 +37,16 @@
 }
 
 .rdp-day--selected,
-.react-datepicker__day--selected,
-.react-datepicker__day--keyboard-selected {
+.react-datepicker__day--selected {
   background: #fef9c3 !important;
   color: #a16207 !important;
+  border-radius: 0.375rem;
+}
+
+.react-datepicker__day--keyboard-selected {
+  background: transparent !important;
+  color: inherit !important;
+  outline-offset: -1px;
   border-radius: 0.375rem;
 }
 

--- a/src/components/commons/calendar/Calendar.tsx
+++ b/src/components/commons/calendar/Calendar.tsx
@@ -12,6 +12,7 @@ import {
 import { offset, shift } from '@floating-ui/dom'
 import './Calendar.style.css'
 import { Z_INDEX } from '@constants/ui'
+import { useState } from 'react'
 
 type RDPProps = React.ComponentProps<typeof ReactDatePicker>
 
@@ -46,17 +47,34 @@ export default function Calendar({
 }: CalendarProps) {
   const triggerWidth = fullWidth ? undefined : width
 
+  const [open, setOpen] = useState<boolean>(false)
+
+  const handleChange = (d: Date | null) => {
+    onChange(d)
+    setOpen(false)
+  }
+
+  const handlePickToday = () => {
+    onChange(new Date())
+    setOpen(false)
+  }
+
   return (
     <ReactDatePicker
       selected={value}
-      onChange={(d) => onChange(d)}
+      onChange={handleChange}
       dateFormat={dateFormat}
       disabled={disabled}
       withPortal={false}
       popperPlacement="bottom-start"
       popperModifiers={[offset(8), shift({ padding: 8 })]}
       shouldCloseOnSelect
-      calendarClassName="inline-block rounded-xl bg-white p-3 shadow-xl ring-1 ring-black/5 border-0"
+      open={open}
+      onCalendarOpen={() => setOpen(true)}
+      onCalendarClose={() => setOpen(false)}
+      onInputClick={() => !disabled && setOpen(true)}
+      onClickOutside={() => setOpen(false)}
+      calendarClassName="inline-block rounded-xl bg-white p-3 border border-gray-300"
       popperClassName={`${Z_INDEX.DROPDOWN}`}
       wrapperClassName={fullWidth ? 'block w-full' : undefined}
       showPopperArrow={false}
@@ -86,7 +104,7 @@ export default function Calendar({
             <button
               type="button"
               className="text-primary-500 hover:text-primary-500 text-sm font-semibold"
-              onClick={() => onChange(new Date())}
+              onClick={handlePickToday}
             >
               오늘
             </button>

--- a/src/components/commons/calendar/DateTriggerButton.tsx
+++ b/src/components/commons/calendar/DateTriggerButton.tsx
@@ -35,7 +35,11 @@ const DateTriggerButton = forwardRef<HTMLButtonElement, DateTriggerButtonProps>(
         ref={ref}
         onClick={onClick}
         disabled={disabled}
-        className={cn(buttonVariants({ variant, size, fullWidth }), className)}
+        className={cn(
+          buttonVariants({ variant, size, fullWidth }),
+          'cursor-pointer',
+          className
+        )}
         style={{ width }}
       >
         <span

--- a/src/components/commons/calendar/data-trigger-button.style.ts
+++ b/src/components/commons/calendar/data-trigger-button.style.ts
@@ -5,7 +5,7 @@ export const buttonVariants = cva(
     'inline-flex items-center justify-between flex-wrap', // 내부 아이템 정렬
     'rounded-xl border text-sm bg-white', // 모양, 기본 배경
     'transition-colors', // hover 등 색상 전환 부드럽게
-    'focus:outline-none focus:ring-2 focus:ring-blue-500/50', // 포커스 상태
+    'focus:outline-none focus:ring-1 focus:ring-gray-200', // 포커스 상태
     'disabled:cursor-not-allowed disabled: opacity-60', // 비활성화 상태
   ].join(' '),
   {

--- a/src/components/recruitment-create/StudyIntroMarkdown.tsx
+++ b/src/components/recruitment-create/StudyIntroMarkdown.tsx
@@ -32,7 +32,7 @@ export default function StudyIntroMarkdown({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         style={{ height }}
-        className="block w-full resize-none border-t border-gray-200 bg-white p-3 text-sm outline-none focus:ring-2 focus:ring-blue-500/30"
+        className="block w-full resize-none border-t border-gray-200 bg-white p-3 text-sm outline-none"
       />
     ),
     preview: <MdPreview embedded value={value} height={height} />,

--- a/src/components/recruitment-create/markdown-ui/MdPreview.tsx
+++ b/src/components/recruitment-create/markdown-ui/MdPreview.tsx
@@ -33,14 +33,7 @@ export default function MdPreview({
           ul: (p) => <ul {...p} className="my-2 ml-5 list-disc" />,
           ol: (p) => <ol {...p} className="my-2 ml-5 list-decimal" />,
           li: (p) => <li {...p} className="my-1" />,
-          a: (p) => (
-            <a
-              {...p}
-              className="text-blue-600 underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          ),
+          a: (p) => <a {...p} target="_blank" rel="noopener noreferrer" />,
           code: (p) => (
             <code {...p} className="rounded bg-gray-100 px-1 py-0.5" />
           ),

--- a/src/components/recruitment-create/markdown-ui/MdPreview.tsx
+++ b/src/components/recruitment-create/markdown-ui/MdPreview.tsx
@@ -33,7 +33,14 @@ export default function MdPreview({
           ul: (p) => <ul {...p} className="my-2 ml-5 list-disc" />,
           ol: (p) => <ol {...p} className="my-2 ml-5 list-decimal" />,
           li: (p) => <li {...p} className="my-1" />,
-          a: (p) => <a {...p} target="_blank" rel="noopener noreferrer" />,
+          a: (p) => (
+            <a
+              {...p}
+              className="text-blue-600 underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          ),
           code: (p) => (
             <code {...p} className="rounded bg-gray-100 px-1 py-0.5" />
           ),


### PR DESCRIPTION
## 📌 개요

- 캘린더와 커스텀 마크다운의 ui를 개선한 작업을 진행하여 이를 PR 생성.

## 🔧 작업 내용

- [ ] `Calendar.style.css`: 오늘을 클릭해도 모달이 꺼지지 않는 상태 수정, 다른 달에서도 전에 클릭한 요일의 색깔이 표시되는 현상 수정.
- [ ] `Calendar`: `onClick` 이벤트를 추가하여, 오늘이 꺼질 수 있도록 세팅.
- [ ]  `data-trigger-button.style.ts`: 색상 수정 (`ring-blue-500/50` -> `ring-gray-200`)
- [ ] `StudyIntroMarkdown`: focus 제거
- [ ] `DateTriggerButton`: `cursor-pointer` 속성 추가

## 📎 관련 이슈

closes #167 

## 💬 리뷰어 참고 사항

- 색상 관련으로 어울리지 않는 부분들 리팩토링 작업 진행했습니다.
