### PR TITLE
feat: 공고 상세페이지 본문 내용 구현

### DIFF
--- a/src/components/recruitment-detail/recruitment-content/ExPostContent.tsx
+++ b/src/components/recruitment-detail/recruitment-content/ExPostContent.tsx
@@ -1,0 +1,107 @@
+// 임시 데이터로 API 연결 시 삭제
+export default function ExPostContent() {
+  const s = {
+    article: 'max-w-3xl mx-auto',
+    title: 'text-2xl font-bold mb-4',
+    paragraph: 'text-base leading-relaxed mb-6',
+    sectionTitle: 'text-xl font-semibold mt-8',
+    list: 'list-disc list-inside space-y-1 text-base leading-relaxed mb-6 ml-6 mt-3',
+    image: 'w-full rounded-lg shadow mb-8',
+  }
+
+  return (
+    <article className={s.article}>
+      {/* 공고 제목 */}
+      <h3 className={s.title}>Unity 게임 개발 프로젝트 팀원 모집</h3>
+      <p className={s.paragraph}>
+        Unity를 활용한 3D 게임 개발 프로젝트를 함께 진행할 팀원을 모집합니다!
+      </p>
+
+      {/* 프로젝트 소개 */}
+      <h4 className={s.sectionTitle}>프로젝트 소개</h4>
+      <ul className={s.list}>
+        <li>
+          <b>Unity 3D 게임 엔진</b> : 최신 Unity 2022.3 LTS 버전 활용
+        </li>
+        <li>
+          <b>CM 프로젝트</b> : 게임 코어 시스템 구현
+        </li>
+        <li>
+          <b>3D 모델링</b> : Blender를 활용한 3D 에셋 제작
+        </li>
+        <li>
+          <b>게임 디자인</b> : 재미있고 흥미로운 게임플레이 설계
+        </li>
+      </ul>
+
+      {/* 모집 대상 */}
+      <h4 className={s.sectionTitle}>모집 대상</h4>
+      <ul className={s.list}>
+        <li>C# 기초 지식이 있으신 분</li>
+        <li>Unity 엔진에 관심이 있으신 분</li>
+        <li>게임 개발 경험을 쌓고 싶으신 분</li>
+        <li>팀워크를 통해 성장하고 싶으신 분</li>
+      </ul>
+
+      {/* 프로젝트 일정 */}
+      <h4 className={s.sectionTitle}>프로젝트 일정</h4>
+      <ul className={s.list}>
+        <li>기간 : 4개월 (2024년 12월 ~ 2025년 3월)</li>
+        <li>방식 : 온라인/오프라인 병행 (월 1회 오프라인)</li>
+        <li>미팅 : 주 3회 (화, 목, 토) 오후 7시</li>
+      </ul>
+      <img
+        src="https://placehold.co/120x70?text=ex"
+        alt="프로젝트 이미지"
+        className={s.image}
+      />
+
+      {/* 개발 예정 게임 */}
+      <h4 className={s.sectionTitle}>개발 예정 게임</h4>
+      <p className={s.paragraph}>
+        <b>3D 액션 어드벤처 게임</b>
+      </p>
+      <ul className={s.list}>
+        <li>플레이어는 미지의 행성을 탐험하며 퍼즐을 해결</li>
+        <li>몬스터와의 전투 시스템</li>
+        <li>아이템 수집 및 캐릭터 성장 요소</li>
+        <li>멀티플레이어 협동 모드</li>
+      </ul>
+
+      {/* 사용 기술 스택 */}
+      <h4 className={s.sectionTitle}>사용 기술 스택</h4>
+      <ul className={s.list}>
+        <li>
+          <b>게임 엔진</b> : Unity 2022.3 LTS
+        </li>
+        <li>
+          <b>프로그래밍</b> : C#
+        </li>
+        <li>
+          <b>버전 관리</b> : Git, GitHub
+        </li>
+        <li>
+          <b>3D 모델링</b> : Blender
+        </li>
+        <li>
+          <b>UI/UX 디자인</b> : Figma
+        </li>
+      </ul>
+
+      <img
+        src="https://placehold.co/120x70?text=ex"
+        alt="게임 이미지"
+        className={s.image}
+      />
+
+      {/* 예상 결과물 */}
+      <h4 className={s.sectionTitle}>예상 결과물</h4>
+      <ul className={s.list}>
+        <li>완성된 3D 게임 프로토타입</li>
+        <li>Steam 플랫폼 배포 경험</li>
+        <li>게임 개발 프로세스 구축</li>
+        <li>Unity 전문 개발자로 성장</li>
+      </ul>
+    </article>
+  )
+}

--- a/src/components/recruitment-detail/recruitment-content/RecruitmentContent.tsx
+++ b/src/components/recruitment-detail/recruitment-content/RecruitmentContent.tsx
@@ -1,0 +1,10 @@
+import ExPostContent from './ExPostContent'
+
+export default function RecruitmentContent() {
+  return (
+    <div className="w-full rounded-xl border border-gray-200 bg-white p-8 pb-18">
+      <h3 className="mb-4 pb-6 text-2xl font-bold">공고 내용</h3>
+      <ExPostContent /> {/* 임시 공고 내용 데이터 */}
+    </div>
+  )
+}

--- a/src/pages/RecruitmentDetailPage.tsx
+++ b/src/pages/RecruitmentDetailPage.tsx
@@ -1,5 +1,6 @@
 import RecruitmentBanner from '@components/recruitment-detail/recruitment-banner/RecruitmentBanner.tsx'
 import BackButton from '@src/components/commons/BackButton'
+import RecruitmentContent from '@src/components/recruitment-detail/recruitment-content/RecruitmentContent'
 
 export default function RecruitmentDetailPage() {
   return (
@@ -10,6 +11,7 @@ export default function RecruitmentDetailPage() {
         </div>
         <div className="flex flex-col gap-8">
           <RecruitmentBanner />
+          <RecruitmentContent />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 개요
상세페이지 본문 내용 박스을 구현합니다.

## 🔧 작업 내용
- 상세페이지 본문 내용 임시 데이터 제작
- 본문 내용 박스을 구현

## 📎 관련 이슈
closes #171

## 📸 스크린샷
<img width="493" height="1012" alt="image" src="https://github.com/user-attachments/assets/6785902c-52ae-45a4-bffc-e463607bda2d" />

## 💬 리뷰어 참고 사항
현재 공고 상세페이지는 원래 API에서 받아온 데이터를 유형에 맞게 가공하여 렌더링해야 합니다. 그러나 백엔드 담당자의 부재로 인해 데이터 유형을 알 수 없어, 데이터를 가공하는 과정은 생략한 상태입니다. 추후 데이터 유형이 확정되면 해당 부분을 수정할 예정이며, 현재는 임시 데이터를 활용해 컴포넌트를 제작하여 넣었음을 양해 부탁드립니다.
