### PR TITLE
feat: 공고 상세페이지 스터디 강의 목록 구현

### DIFF
--- a/src/components/recruitment-detail/recuitment-courses/CoursesCard.tsx
+++ b/src/components/recruitment-detail/recuitment-courses/CoursesCard.tsx
@@ -1,0 +1,28 @@
+import type { CourseCardData } from '@src/mock/postDetailCourses'
+import { ArrowRight as ArrowRightIcon } from 'lucide-react'
+
+export interface CourseCardProps {
+  course: CourseCardData
+}
+
+export default function CoursesCard({ course }: CourseCardProps) {
+  return (
+    <div className="overflow-hidden rounded border border-gray-200">
+      <img
+        src="https://placehold.co/120x70?text=ex"
+        alt="강의 이미지"
+        className="h-48 w-full object-cover"
+      />
+      <div className="p-6">
+        <h5 className="mb-2 text-lg font-semibold">{course.name}</h5>
+        <p className="mb-3 text-gray-600">강사: {course.instructor}</p>
+        <div className="text-primary-600 flex items-center justify-between">
+          <h4 className="text-xl font-semibold">{course.price}</h4>
+          <a href={course.url} className="flex items-center">
+            강의 보기 <ArrowRightIcon className="h-4" />
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/recruitment-detail/recuitment-courses/CoursesCard.tsx
+++ b/src/components/recruitment-detail/recuitment-courses/CoursesCard.tsx
@@ -18,7 +18,7 @@ export default function CoursesCard({ course }: CourseCardProps) {
         <p className="mb-3 text-gray-600">강사: {course.instructor}</p>
         <div className="text-primary-600 flex items-center justify-between">
           <h4 className="text-xl font-semibold">{course.price}</h4>
-          <a href={course.url} className="flex items-center">
+          <a href={course.url} className="flex items-center hover:underline">
             강의 보기 <ArrowRightIcon className="h-4" />
           </a>
         </div>

--- a/src/components/recruitment-detail/recuitment-courses/RecuitmentCourses.tsx
+++ b/src/components/recruitment-detail/recuitment-courses/RecuitmentCourses.tsx
@@ -1,0 +1,23 @@
+import CoursesCard from './CoursesCard'
+import { postDetailCourseData } from '@src/mock/postDetailCourses'
+
+export default function RecuitmentCourses() {
+  const coursesForCard = postDetailCourseData.map((course) => ({
+    id: course.id,
+    name: course.name,
+    instructor: course.instructor,
+    price: course.price,
+    url: course.url,
+  }))
+
+  return (
+    <div className="w-full rounded-xl border border-gray-200 bg-white p-8">
+      <h3 className="mb-4 pb-6 text-2xl font-bold">스터디 강의 목록</h3>
+      <div className="grid grid-cols-2 gap-6">
+        {coursesForCard.map((course) => (
+          <CoursesCard key={course.id} course={course} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/mock/postDetailCourses.ts
+++ b/src/mock/postDetailCourses.ts
@@ -1,0 +1,24 @@
+export interface CourseCardData {
+  id: number
+  name: string
+  instructor: string
+  price: number
+  url: string
+}
+
+export const postDetailCourseData: CourseCardData[] = [
+  {
+    id: 1,
+    name: 'Unity 게임 개발 마스터클래스',
+    instructor: '박유니티',
+    price: 120000,
+    url: 'ozcodingschool.com/ozcoding/gamedevcamp',
+  },
+  {
+    id: 2,
+    name: 'C# 게임 프로그래밍',
+    instructor: '김씨샵',
+    price: 60000,
+    url: 'ozcodingschool.com/ozcoding/aileadercamp',
+  },
+]

--- a/src/pages/RecruitmentDetailPage.tsx
+++ b/src/pages/RecruitmentDetailPage.tsx
@@ -1,6 +1,7 @@
 import RecruitmentBanner from '@components/recruitment-detail/recruitment-banner/RecruitmentBanner.tsx'
 import BackButton from '@src/components/commons/BackButton'
 import RecruitmentContent from '@src/components/recruitment-detail/recruitment-content/RecruitmentContent'
+import RecuitmentCourses from '@src/components/recruitment-detail/recuitment-courses/RecuitmentCourses'
 
 export default function RecruitmentDetailPage() {
   return (
@@ -12,6 +13,7 @@ export default function RecruitmentDetailPage() {
         <div className="flex flex-col gap-8">
           <RecruitmentBanner />
           <RecruitmentContent />
+          <RecuitmentCourses />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 개요
공고 상세페이지 스터디 강의 목록 구현합니다.

## 🔧 작업 내용
- 강의 mock 데이터 추가
- 강의 카드 구현
- 강의 컴포넌트 구현

## 📎 관련 이슈
closes #172

## 📸 스크린샷
<img width="735" height="430" alt="image" src="https://github.com/user-attachments/assets/4c403903-3e02-48d2-a19e-53ed00e660d3" />
