### PR TITLE
fix: 구인 공고 작성 페이지 중앙정렬이 안맞는 현상 수정

### DIFF
--- a/src/components/recruitment-create/RecCreateHeader.tsx
+++ b/src/components/recruitment-create/RecCreateHeader.tsx
@@ -2,10 +2,10 @@ import BackButton from '@components/commons/BackButton'
 
 export default function RecCreateHeader() {
   return (
-    <div className="flex h-full w-full items-center justify-between">
-      <div className="flex h-16 w-[447.78px] items-center justify-center">
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="flex h-16 w-full max-w-[832px] items-center">
         <BackButton />
-        <div className="ml-4 flex h-full w-[391.78px] flex-col">
+        <div className="ml-4 flex flex-col">
           <p className="text-[30px] leading-9 font-bold text-gray-900">
             스터디 구인 공고 작성
           </p>

--- a/src/components/recruitment-edit/RecEditHeader.tsx
+++ b/src/components/recruitment-edit/RecEditHeader.tsx
@@ -2,10 +2,10 @@ import BackButton from '../commons/BackButton'
 
 export default function RecEditHeader() {
   return (
-    <div className="flex h-full w-full items-center justify-between">
-      <div className="flex h-16 w-[447.78px] items-center justify-center">
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="flex h-16 w-full max-w-[832px] items-center">
         <BackButton />
-        <div className="ml-4 flex h-full w-[391.78px] flex-col">
+        <div className="ml-4 flex flex-col">
           <p className="text-[30px] leading-9 font-bold text-gray-900">
             스터디 구인 공고 수정
           </p>

--- a/src/pages/RecruitmentCreate.tsx
+++ b/src/pages/RecruitmentCreate.tsx
@@ -7,7 +7,7 @@ import RecCreateFooter from '@src/components/recruitment-create/RecCreateFooter'
 export default function RecruitmentCreate() {
   return (
     <div className="min-h-dvh w-full">
-      <div className="mx-auto mt-8 flex w-full max-w-[1120px] flex-col gap-8 px-6 lg:px-12">
+      <div className="mx-auto mt-8 flex w-full max-w-[1120px] flex-col items-center gap-8 px-6 lg:px-12">
         <RecCreateHeader />
         <RecCreateBasicInfo />
         <RecCreateContentSection />

--- a/src/pages/RecruitmentEdit.tsx
+++ b/src/pages/RecruitmentEdit.tsx
@@ -31,7 +31,7 @@ export default function RecruitmentEdit() {
 
   return (
     <div className="min-h-dvh w-full">
-      <div className="mx-auto mt-8 flex w-full max-w-[1120px] flex-col gap-8 px-6 lg:px-12">
+      <div className="mx-auto mt-8 flex w-full max-w-[1120px] flex-col items-center gap-8 px-6 lg:px-12">
         <RecEditHeader />
         <RecEditBasicInfo
           title={MOCKDATA.title}


### PR DESCRIPTION
## 📌 개요

- 구인공고 작성 페이지의 틀을 같이 사용하는 공소 수정 페이지까지 중앙정렬이 맞지 않는 현상이 발생되어 수정 후 PR.

## 🔧 작업 내용

- [ ] `RecruitmentCreate`: `items-center` 추가
- [ ] `RecruitmentEdit`: `items-center` 추가
- [ ] `RecCreateHeader`: width와 height 설정 변경
- [ ] `RecEditHeader`: width와 height 설정 변경

## 📎 관련 이슈

closes #183 

## 💬 리뷰어 참고 사항

- 상단 div만 수정했습니다.
