### PR TITLE
feat: 공고 상세 페이지 첨부 파일 컴포넌트 구현

### DIFF
--- a/src/components/recruitment-detail/recruitment-attachment-list/RecruitmentAttachmentFile.tsx
+++ b/src/components/recruitment-detail/recruitment-attachment-list/RecruitmentAttachmentFile.tsx
@@ -1,0 +1,31 @@
+import type { Attachments } from '@src/mock/postDetailAttachments'
+import { Download as DownloadIcon, FileText as FileIcon } from 'lucide-react'
+
+interface RecruitmentAttachmentFileProps {
+  file: Attachments
+}
+
+export default function RecruitmentAttachmentFile({
+  file,
+}: RecruitmentAttachmentFileProps) {
+  return (
+    <div className="flex w-full items-center justify-between rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100">
+          <FileIcon className="h-5 w-5 text-blue-600" />
+        </div>
+        <div>
+          <p className="font-medium">{file.file_name}</p>
+        </div>
+      </div>
+      <a
+        href={file.file_url}
+        download={file.file_name}
+        className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-200 active:bg-gray-300 disabled:bg-gray-100"
+      >
+        <DownloadIcon className="h-4 w-4" />
+        <p>다운로드</p>
+      </a>
+    </div>
+  )
+}

--- a/src/components/recruitment-detail/recruitment-attachment-list/RecruitmentAttachmentList.tsx
+++ b/src/components/recruitment-detail/recruitment-attachment-list/RecruitmentAttachmentList.tsx
@@ -1,0 +1,15 @@
+import { postDetailAttachments } from '@src/mock/postDetailAttachments'
+import RecruitmentAttachmentFile from './RecruitmentAttachmentFile'
+
+export default function RecruitmentAttachmentList() {
+  return (
+    <div className="w-full rounded-xl border border-gray-200 bg-white p-8">
+      <h3 className="mb-4 pb-6 text-2xl font-bold">첨부 파일</h3>
+      <div className="flex flex-col gap-4">
+        {postDetailAttachments.map((file) => (
+          <RecruitmentAttachmentFile key={file.id} file={file} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/mock/postDetailAttachments.tsx
+++ b/src/mock/postDetailAttachments.tsx
@@ -1,0 +1,20 @@
+export interface Attachments {
+  id: number
+  file_name: string
+  file_url: string
+}
+
+export const postDetailAttachments: Attachments[] = [
+  {
+    id: 1,
+    file_name: '게임_기획서.pdf',
+    file_url:
+      'https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyMzEyMTNfMTcg%2FMDAxNzAyNDczNjIzMzQ3.aZloZFhvYPgMlsDrwUGJ53Dj4_9u7EXFmY7dtMLnwBsg.MqutBq_-lnapCvYGdY90kDOyWwGOryGsHEIT_iYArcog.GIF.jsoie123%2FIMG_5959.GIF&type=sc960_832_gif',
+  },
+  {
+    id: 2,
+    file_name: 'Unity_개발환경_설정가이드.docx',
+    file_url:
+      'https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyMzEyMTNfMTcg%2FMDAxNzAyNDczNjIzMzQ3.aZloZFhvYPgMlsDrwUGJ53Dj4_9u7EXFmY7dtMLnwBsg.MqutBq_-lnapCvYGdY90kDOyWwGOryGsHEIT_iYArcog.GIF.jsoie123%2FIMG_5959.GIF&type=sc960_832_gif',
+  },
+]

--- a/src/pages/RecruitmentDetailPage.tsx
+++ b/src/pages/RecruitmentDetailPage.tsx
@@ -1,5 +1,6 @@
 import RecruitmentBanner from '@components/recruitment-detail/recruitment-banner/RecruitmentBanner.tsx'
 import BackButton from '@src/components/commons/BackButton'
+import RecruitmentAttachmentList from '@src/components/recruitment-detail/recruitment-attachment-list/RecruitmentAttachmentList'
 import RecruitmentContent from '@src/components/recruitment-detail/recruitment-content/RecruitmentContent'
 import RecuitmentCourses from '@src/components/recruitment-detail/recuitment-courses/RecuitmentCourses'
 
@@ -14,6 +15,7 @@ export default function RecruitmentDetailPage() {
           <RecruitmentBanner />
           <RecruitmentContent />
           <RecuitmentCourses />
+          <RecruitmentAttachmentList />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 개요
공고 상세 페이지의 첨부 파일이 포함된 컴포넌트를 구현합니다.

## 🔧 작업 내용
- 첨부 파일 mock 데이터 생성
- 첨부 파일 컴포넌트 구현

## 📎 관련 이슈
closes #173

## 📸 스크린샷
<img width="728" height="293" alt="image" src="https://github.com/user-attachments/assets/976ef0e6-fc06-496e-b968-5df9ae65fc8d" />

## 💬 리뷰어 참고 사항
- 추후 분리되어 있는 상세 mock 데이터들을 하나로 합칠 예정입니다.
- 구현된 컴포넌트는 파일 용량이 없는 상태인데 백엔드에서 데이터를 주지 않아 프론트에서 삭제하는걸로 타협했습니다.
- 파일 다운로드 하는 방법중에 가장 간단한 a태그를 사용하는 방법을 채택하였는데 그로인해 버튼 컴포넌트를 사용하지 않아 직접 스타일 코드를 넣게 되었습니다.
