### PR TITLE
refactor: 스터디 구인 공고 제작 페이지 리펙토링

### DIFF
--- a/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
+++ b/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
@@ -1,6 +1,5 @@
 import RecEditPriceInput from '../recruitment-edit/RecEditPriceInput'
 import { FileUploadBox } from './FileUploadBox'
-
 import TagBox from './tag-ui/TagBox'
 
 interface PresetFile {
@@ -9,17 +8,30 @@ interface PresetFile {
   url: string
 }
 
-interface RecCreateAdditionalInfoProps {
-  price?: string
-  onPriceChange?: (raw: string) => void
+interface Props {
+  derivedPrice?: string
+  override: string | null
+  onChangeOverride: (raw: string) => void
   defaultFiles?: PresetFile[]
 }
 
+const formatPrice = (s?: string) =>
+  s ? new Intl.NumberFormat('ko-KR').format(Number(s)) : ''
+
 export default function RecCreateAdditionalInfo({
-  price,
-  onPriceChange,
+  derivedPrice = '',
+  override,
+  onChangeOverride,
   defaultFiles,
-}: RecCreateAdditionalInfoProps) {
+}: Props) {
+  const inputValue = override === null ? derivedPrice : override
+  const valueForInput = override === '' ? '' : inputValue
+
+  let placeholder = '미입력시 스터디 그룹 비용 자동 계산'
+  if (override === '') {
+    placeholder = formatPrice(derivedPrice) || '금액 입력'
+  }
+
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
       <p className="text-[20px] leading-7 font-semibold">추가 정보</p>
@@ -28,15 +40,14 @@ export default function RecCreateAdditionalInfo({
         예상 결제 비용 (원)
       </label>
       <RecEditPriceInput
-        value={price ?? ''}
-        onChange={(raw) => onPriceChange?.(raw)}
-        placeholder="미입력시 스터디 그룹 비용 자동 계산"
+        value={valueForInput}
+        onChange={onChangeOverride}
+        placeholder={placeholder}
       />
 
       <div className="mt-6">
         <TagBox />
       </div>
-
       <div className="mt-6">
         <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
           참고 파일 업로드 (선택사항)

--- a/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
+++ b/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
@@ -1,24 +1,47 @@
+import RecEditPriceInput from '../recruitment-edit/RecEditPriceInput'
 import { FileUploadBox } from './FileUploadBox'
-import PriceInput from './PriceInput'
+
 import TagBox from './tag-ui/TagBox'
 
-export default function RecCreateAdditionalInfo() {
+interface PresetFile {
+  id: number
+  name: string
+  url: string
+}
+
+interface RecCreateAdditionalInfoProps {
+  price?: string
+  onPriceChange?: (raw: string) => void
+  defaultFiles?: PresetFile[]
+}
+
+export default function RecCreateAdditionalInfo({
+  price,
+  onPriceChange,
+  defaultFiles,
+}: RecCreateAdditionalInfoProps) {
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
       <p className="text-[20px] leading-7 font-semibold">추가 정보</p>
-      {/* 예상 결제 비용 field*/}
+
       <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
         예상 결제 비용 (원)
       </label>
-      <PriceInput />
+      <RecEditPriceInput
+        value={price ?? ''}
+        onChange={(raw) => onPriceChange?.(raw)}
+        placeholder="미입력시 스터디 그룹 비용 자동 계산"
+      />
+
       <div className="mt-6">
         <TagBox />
       </div>
+
       <div className="mt-6">
         <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
           참고 파일 업로드 (선택사항)
         </label>
-        <FileUploadBox />
+        <FileUploadBox defaultFiles={defaultFiles} />
       </div>
     </div>
   )

--- a/src/components/recruitment-create/RecCreateBasicInfo.tsx
+++ b/src/components/recruitment-create/RecCreateBasicInfo.tsx
@@ -1,6 +1,10 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import DropDown from '../commons/dropdown/DropDown'
 import Calendar from '../commons/calendar/Calendar'
+import {
+  getCoursesForGroup,
+  sumCoursePrices,
+} from '@src/mock/studyGroupCourseMap'
 
 const studyGroup = [
   { id: 1, name: '스터디 그룹1' },
@@ -16,12 +20,30 @@ const capacityGroup = [
   { id: 4, name: '4명' },
   { id: 5, name: '5명' },
   { id: 6, name: '6명' },
+  { id: 7, name: '7명' },
+  { id: 8, name: '8명' },
+  { id: 9, name: '9명' },
+  { id: 10, name: '10명' },
 ]
 
-export default function RecCreateBasicInfo() {
+const formatPrice = (n: number) => new Intl.NumberFormat('ko-KR').format(n)
+
+interface RecCreateBasicInfoProps {
+  onGroupChange?: (name: string | undefined) => void
+}
+
+export default function RecCreateBasicInfo({
+  onGroupChange,
+}: RecCreateBasicInfoProps) {
   const [selectedGroup, setSelectedGroup] = useState<string>()
   const [selectedCapacity, setSelectedCapacity] = useState<string>()
   const [deadLine, setDeadLine] = useState<Date | null>(null)
+
+  const courses = useMemo(
+    () => getCoursesForGroup(selectedGroup),
+    [selectedGroup]
+  )
+  const total = useMemo(() => sumCoursePrices(courses), [courses])
 
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
@@ -56,9 +78,44 @@ export default function RecCreateBasicInfo() {
       <DropDown
         selected={selectedGroup}
         options={studyGroup}
-        onSelect={setSelectedGroup}
+        onSelect={(name) => {
+          setSelectedGroup(name)
+          onGroupChange?.(name)
+        }}
         placeholder="스터디 그룹을 선택해주세요"
       />
+
+      {/* 선택된 그룹의 강의 정보 패널 */}
+      {courses.length > 0 && (
+        <div className="mt-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4">
+          <p className="text-primary-800 mb-2 text-sm">
+            선택된 그룹의 강의 정보
+          </p>
+          <ul className="space-y-1">
+            {courses.map((course) => (
+              <li
+                key={course.id}
+                className="flex items-center justify-between py-1"
+              >
+                <span className="text-primary-700 text-[14px]">
+                  {course.title}
+                </span>
+                <span className="text-primary-700 text-[14px] font-medium">
+                  {formatPrice(course.price)}원
+                </span>
+              </li>
+            ))}
+            <li className="border-primary-200 mt-1 flex items-center justify-between border-t pt-2">
+              <span className="text-primary-800 text-[14px] font-medium">
+                총 강의 비용
+              </span>
+              <span className="text-primary-800 text-[14px] font-medium">
+                {formatPrice(total)}원
+              </span>
+            </li>
+          </ul>
+        </div>
+      )}
 
       {/* 공고 마감 기한 & 예상 모집 인원 field*/}
       <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/src/components/recruitment-create/RecCreateContentSection.tsx
+++ b/src/components/recruitment-create/RecCreateContentSection.tsx
@@ -35,13 +35,6 @@ export default function RecCreateContentSection() {
         <p>• 마크다운 문법: **굵게**, *기울임*, # 제목, - 목록 등</p>
         <p>• 이미지 추가: ![설명](이미지URL) - 최대 5개, 각 5MB 이하</p>
       </div>
-
-      <div className="mt-8">
-        <label className="mt-2 mb-2 block text-sm leading-5 font-medium text-gray-700">
-          스터디 그룹 대표 이미지(선택사항)
-        </label>
-        <ImageUploadBox />
-      </div>
     </div>
   )
 }

--- a/src/components/recruitment-create/RecCreateContentSection.tsx
+++ b/src/components/recruitment-create/RecCreateContentSection.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import StudyIntroMarkdown from './StudyIntroMarkdown'
-import { ImageUploadBox } from './ImageUploadBox'
 import { STUDY_INTRO_PLACEHOLDER } from '@src/constants/studyintroplaceholder'
 
 const PLACEHOLDER = STUDY_INTRO_PLACEHOLDER

--- a/src/pages/RecruitmentCreate.tsx
+++ b/src/pages/RecruitmentCreate.tsx
@@ -3,15 +3,39 @@ import RecCreateAdditionalInfo from '@src/components/recruitment-create/RecCreat
 import RecCreateContentSection from '@src/components/recruitment-create/RecCreateContentSection'
 import RecCreateHeader from '@src/components/recruitment-create/RecCreateHeader'
 import RecCreateFooter from '@src/components/recruitment-create/RecCreateFooter'
+import { useMemo, useState } from 'react'
+import {
+  getCoursesForGroup,
+  sumCoursePrices,
+} from '@src/mock/studyGroupCourseMap'
 
 export default function RecruitmentCreate() {
+  const [studyGroup, setStudyGroup] = useState<string | undefined>(undefined)
+  const [priceOverride, setPriceOverride] = useState<string | null>(null)
+
+  const courses = useMemo(() => getCoursesForGroup(studyGroup), [studyGroup])
+
+  const price = useMemo(
+    () => (courses?.length ? String(sumCoursePrices(courses)) : ''),
+    [courses]
+  )
+
+  const priceForInput = priceOverride ?? price
+
   return (
     <div className="min-h-dvh w-full">
       <div className="mx-auto mt-8 flex w-full max-w-[1120px] flex-col items-center gap-8 px-6 lg:px-12">
         <RecCreateHeader />
-        <RecCreateBasicInfo />
+        <RecCreateBasicInfo
+          onGroupChange={(name) => {
+            setStudyGroup(name)
+          }}
+        />
         <RecCreateContentSection />
-        <RecCreateAdditionalInfo />
+        <RecCreateAdditionalInfo
+          price={priceForInput}
+          onPriceChange={(raw) => setPriceOverride(raw === '' ? null : raw)}
+        />
         <RecCreateFooter />
       </div>
     </div>

--- a/src/pages/RecruitmentCreate.tsx
+++ b/src/pages/RecruitmentCreate.tsx
@@ -10,17 +10,14 @@ import {
 } from '@src/mock/studyGroupCourseMap'
 
 export default function RecruitmentCreate() {
-  const [studyGroup, setStudyGroup] = useState<string | undefined>(undefined)
+  const [studyGroup, setStudyGroup] = useState<string | undefined>()
   const [priceOverride, setPriceOverride] = useState<string | null>(null)
 
   const courses = useMemo(() => getCoursesForGroup(studyGroup), [studyGroup])
-
-  const price = useMemo(
-    () => (courses?.length ? String(sumCoursePrices(courses)) : ''),
+  const derivedPrice = useMemo(
+    () => (courses.length ? String(sumCoursePrices(courses)) : ''),
     [courses]
   )
-
-  const priceForInput = priceOverride ?? price
 
   return (
     <div className="min-h-dvh w-full">
@@ -29,12 +26,14 @@ export default function RecruitmentCreate() {
         <RecCreateBasicInfo
           onGroupChange={(name) => {
             setStudyGroup(name)
+            setPriceOverride(null)
           }}
         />
         <RecCreateContentSection />
         <RecCreateAdditionalInfo
-          price={priceForInput}
-          onPriceChange={(raw) => setPriceOverride(raw === '' ? null : raw)}
+          derivedPrice={derivedPrice}
+          override={priceOverride}
+          onChangeOverride={(raw) => setPriceOverride(raw)}
         />
         <RecCreateFooter />
       </div>


### PR DESCRIPTION
## 📌 개요

- 스터디 구인 공고 페이지가 현재 수정 페이지와 상이한 부분이 있어서 이를 수정하고 보완하기 위해 리펙토링 작업을 완료하여 이를 PR 요청.

## 🔧 작업 내용

- [ ] `RecCreateContentSection`: 사용하지 않는 이미지 파일 첨부 영역 삭제
- [ ] `RecCreateBasicInfo`: 기본 정보에서 스터디 그룹을 클릭하게 되는 경우에, 하단에 그에 해당하는 스터디 그룹에서 어떠한 강의를 담았으며, 얼마인지를 나타내는 창을 추가
- [ ] `RecCreateAdditionalInfo`: 예상 비용이 상위 props로 받는 방식을 하여, 간단한 상태관리를 진행. 예상 비용을 따로 지우게 되면 placeholder로 원래 예상 비용을 나오는 방식을 채택함.

## 📎 관련 이슈

closes #186 

## 📸 스크린샷

### 1. 기본 정보(대상 스터디 그룹)
<img width="848" height="677" alt="image" src="https://github.com/user-attachments/assets/609da9b3-0618-4e3c-a5a8-f8e0dab3f3a5" />

### 2. 추가 정보(예상 결제 비용 (원))
<img width="816" height="653" alt="image" src="https://github.com/user-attachments/assets/609e71c0-187c-46d3-8e00-5bff9ea443ab" />

### 3. 추가 정보(예상 결제 비용을 지운 경우)
<img width="819" height="653" alt="image" src="https://github.com/user-attachments/assets/62df4a5b-f79e-4f0f-9a84-a5209904b1f9" />

## 💬 리뷰어 참고 사항

- edit페이지에서 사용하는 방식과 좀 더 유사하도록 수정하는 작업을 진행했습니다.
