### PR TITLE
feat: 태그 선택 모달 구현 #159

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
+        "zod": "^4.1.8",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -10552,6 +10553,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.10",
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
+        "badwords-ko": "^1.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.515.0",
@@ -3441,6 +3442,12 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/badwords-ko": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/badwords-ko/-/badwords-ko-1.0.4.tgz",
+      "integrity": "sha512-l2gJiVkIXd1nyyRI6aXEujq+aCiMfCyREUdK68mUnH6iZy8+mvXvkvOLO6Nv6MXiRKgvdUQEmSeuVno38MX+wA==",
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/vite": "^4.1.10",
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
+    "badwords-ko": "^1.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.515.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
+    "zod": "^4.1.8",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/src/api/tag.ts
+++ b/src/api/tag.ts
@@ -1,0 +1,21 @@
+import type { Tag } from '@src/types/tag'
+import axios from 'axios'
+
+export async function fetchTags(params: {
+  search: string
+  page: number
+  size: number
+}) {
+  const res = await axios.get<{ results: Tag[]; count: number }>(
+    '/api/v1/recruitments/tags', // 나중에 basurl 사용하면 바꾸기
+    {
+      params,
+    }
+  )
+  return res.data
+}
+
+export async function createTag(name: string) {
+  const res = await axios.post<Tag>('/api/v1/recruitments/tags', { name })
+  return res.data
+}

--- a/src/components/commons/LoadingSpinner.tsx
+++ b/src/components/commons/LoadingSpinner.tsx
@@ -1,22 +1,26 @@
 import { LOADING_MESSAGES } from '@src/constants/ui'
+import { cn } from '@src/utils/cn'
 
 interface LoadingSpinnerProps {
   message?: string
+  className?: string
 }
 
 export default function LoadingSpinner({
   message = LOADING_MESSAGES.COURSES,
+  className = '',
 }: LoadingSpinnerProps) {
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="flex items-center justify-center py-20">
-        <div className="flex flex-col items-center gap-6">
-          <div className="border-primary-500 mx-auto mb-6 h-12 w-12 animate-spin rounded-full border-b-2"></div>
-          <div className="flex flex-col items-center gap-2">
-            <h4 className="text-xl font-semibold text-gray-900">{message}</h4>
-            <p className="text-base text-gray-500">잠시만 기다려주세요...</p>
-          </div>
-        </div>
+    <div
+      className={cn(
+        'flex h-full w-full flex-col items-center justify-center gap-6 bg-gray-50',
+        className
+      )}
+    >
+      <div className="border-primary-500 mx-auto mb-6 h-12 w-12 animate-spin rounded-full border-b-2"></div>
+      <div className="flex flex-col items-center gap-2">
+        <h4 className="text-lg font-semibold text-gray-900">{message}</h4>
+        <p className="text-md text-gray-500">잠시만 기다려주세요...</p>
       </div>
     </div>
   )

--- a/src/components/commons/SearchBar.tsx
+++ b/src/components/commons/SearchBar.tsx
@@ -29,7 +29,7 @@ export function SearchBar({
   return (
     <div
       className={cn(
-        'mb-6 flex w-112 items-center gap-2 rounded-lg border border-gray-200 p-3',
+        'focus-within:border-primary-400 mb-6 flex w-112 items-center gap-2 rounded-lg border border-gray-200 p-3',
         className
       )}
     >
@@ -40,7 +40,7 @@ export function SearchBar({
         onChange={(e) => setKeyword(e.target.value)}
         placeholder={placeholder}
         aria-label={placeholder}
-        className="focus:border-transparent focus:outline-none"
+        className="w-full focus:border-transparent focus:outline-none"
       />
     </div>
   )

--- a/src/components/commons/form/TextareaWithCounter.tsx
+++ b/src/components/commons/form/TextareaWithCounter.tsx
@@ -21,5 +21,5 @@ const TextareaWithCounter = forwardRef<HTMLTextAreaElement, Props>(
     )
   }
 )
-
+TextareaWithCounter.displayName = 'TextareaWithCounter'
 export default TextareaWithCounter

--- a/src/components/commons/form/TextareaWithCounter.tsx
+++ b/src/components/commons/form/TextareaWithCounter.tsx
@@ -1,24 +1,25 @@
-import type { TextareaHTMLAttributes } from 'react'
+import { forwardRef, type TextareaHTMLAttributes } from 'react'
 
 type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   maxLength: number
   valueLength: number
 }
-export default function TextareaWithCounter({
-  maxLength,
-  valueLength,
-  ...rest
-}: Props) {
-  return (
-    <div className="space-y-1">
-      <textarea
-        className="focus:outline-primary-500 h-[122px] w-full resize-none rounded-lg border border-gray-500 px-3 py-2 placeholder:text-sm placeholder:text-gray-400 placeholder:italic disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
-        maxLength={maxLength}
-        {...rest}
-      />
-      <div className="text-xs text-gray-500">
-        {valueLength}/{maxLength}
+const TextareaWithCounter = forwardRef<HTMLTextAreaElement, Props>(
+  ({ valueLength = 0, maxLength = 500, ...rest }, ref) => {
+    return (
+      <div className="space-y-1">
+        <textarea
+          ref={ref}
+          className="focus:outline-primary-500 h-[122px] w-full resize-none rounded-lg border border-gray-500 px-3 py-2 placeholder:text-sm placeholder:text-gray-400 placeholder:italic disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+          maxLength={maxLength}
+          {...rest}
+        />
+        <div className="text-xs text-gray-500">
+          {valueLength}/{maxLength}
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+)
+
+export default TextareaWithCounter

--- a/src/components/commons/modal/ModalRoot.tsx
+++ b/src/components/commons/modal/ModalRoot.tsx
@@ -29,7 +29,7 @@ export default function ModalRoot({
   size = 'md',
   children,
   className,
-  speed = 'slow',
+  speed = 'fast',
   closeOnOutsideClick = true,
 }: ModalProps) {
   useScrollLock(open)

--- a/src/components/commons/pagination/Pagination.tsx
+++ b/src/components/commons/pagination/Pagination.tsx
@@ -37,9 +37,9 @@ export default function Pagination({
       <Button
         icon={ChevronLeftIcon}
         iconSize="sm"
-        variant="secondary"
+        variant="outline"
         iconClassName="text-gray-500"
-        className="rounded-xl border border-gray-200"
+        className="h-9 w-9 rounded-lg border border-gray-200"
         onClick={() => onPageChange(page - 1)}
         disabled={page <= 1}
         aria-label="이전 페이지"
@@ -49,10 +49,10 @@ export default function Pagination({
           key={pageNum}
           buttonInnerText={String(pageNum)}
           size="base"
-          variant={pageNum === page ? 'primary' : 'secondary'}
+          variant={pageNum === page ? 'primary' : 'outline'}
           onClick={() => onPageChange(pageNum)}
           className={cn(
-            'h-10 w-10 rounded-xl p-0 tabular-nums',
+            'h-9 w-9 rounded-lg p-0 tabular-nums',
             pageNum === page ? '' : 'border border-gray-200'
           )}
           aria-current={pageNum === page ? 'page' : undefined}
@@ -61,9 +61,9 @@ export default function Pagination({
       <Button
         icon={ChevronRightIcon}
         iconSize="sm"
-        variant="secondary"
+        variant="outline"
         iconClassName="text-gray-500"
-        className="rounded-xl border border-gray-200"
+        className="h-9 w-9 rounded-lg border border-gray-200"
         onClick={() => onPageChange(page + 1)}
         disabled={page >= totalPages}
         aria-label="다음 페이지"

--- a/src/components/commons/tag/SelectedTag.tsx
+++ b/src/components/commons/tag/SelectedTag.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react'
 import Icon from '../Icon'
 import Badge from '../Badge'
+import { cn } from '@src/utils/cn'
 
 interface SelectedTagProps {
   label: string
@@ -14,8 +15,15 @@ export default function SelectedTag({
   className,
 }: SelectedTagProps) {
   return (
-    <Badge className={className ?? 'bg-primary-100 text-primary-800'}>
-      {label}
+    <Badge
+      className={cn(
+        'inline-flex max-w-full items-center',
+        className ?? 'bg-primary-100 text-primary-800'
+      )}
+    >
+      <span className="max-w-10 truncate sm:max-w-20" title={label}>
+        {label}
+      </span>
       {onRemove && (
         <button
           type="button"

--- a/src/components/commons/tag/SelectedTag.tsx
+++ b/src/components/commons/tag/SelectedTag.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react'
+import { X as XIcon } from 'lucide-react'
 import Icon from '../Icon'
 import Badge from '../Badge'
 import { cn } from '@src/utils/cn'
@@ -32,7 +32,7 @@ export default function SelectedTag({
           className="ml-2 text-xs leading-none hover:opacity-80"
         >
           <Icon
-            icon={X}
+            icon={XIcon}
             className="hover:text-danger-800 h-3 w-3 cursor-pointer"
             strokeWidth={3}
           />

--- a/src/components/commons/tag/SelectedTagList.tsx
+++ b/src/components/commons/tag/SelectedTagList.tsx
@@ -3,15 +3,15 @@ import SelectedTag from './SelectedTag'
 import { useMemo } from 'react'
 
 export interface TagOption {
-  id: string
+  id: number
   label: string
   colorClass?: string
 }
 
 interface SelectedTagListProps {
-  selectedIds: string[] // 선택된 태그 id 목록
+  selectedIds: number[] // 선택된 태그 id 목록
   options: TagOption[] // id label 매핑
-  onRemove?: (id: string) => void // 선택된 태그 퓌소
+  onRemove?: (id: number) => void // 선택된 태그 퓌소
   className?: string
 }
 
@@ -30,7 +30,7 @@ export default function SelectedTagList({
   const selected = selectedIds
     .map((id) => ({ id, label: optionMap.get(id) }))
     .filter(
-      (tag): tag is { id: string; label: string } => tag.label !== undefined
+      (tag): tag is { id: number; label: string } => tag.label !== undefined
     )
   // selected에는 항상 [{id, label}] 배열 형태
 

--- a/src/components/commons/tag/TagCheckbox.tsx
+++ b/src/components/commons/tag/TagCheckbox.tsx
@@ -30,15 +30,14 @@ export default function TagCheckbox({
     if (checked === undefined) setInnerChecked(next)
     onChange?.(next)
   }
-
   return (
     <label
       htmlFor={id}
       className={cn(
-        'flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border px-4 py-3',
+        'flex h-12 w-full cursor-pointer items-center justify-between rounded-xl border px-4 py-3',
         isChecked
           ? 'border-primary-300 bg-primary-50'
-          : 'hover:border-primary-300 border-gray-400',
+          : 'hover:border-primary-300 border-gray-300',
         className
       )}
     >
@@ -60,7 +59,7 @@ export default function TagCheckbox({
       />
       <span
         className={cn(
-          'flex h-4 w-4 items-center justify-center rounded-sm border-2 border-gray-400 peer-checked:border-none',
+          'flex h-4 w-4 items-center justify-center rounded-sm border-2 border-gray-300 peer-checked:border-none',
           'peer-checked:bg-primary-500 peer-checked:border-none'
         )}
       >

--- a/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
+++ b/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
@@ -1,6 +1,6 @@
 import { FileUploadBox } from './FileUploadBox'
 import PriceInput from './PriceInput'
-import TagBox from './tag-ui/TagBox'
+import TagSection from './tag-ui/TagSection'
 
 export default function RecCreateAdditionalInfo() {
   return (
@@ -12,7 +12,7 @@ export default function RecCreateAdditionalInfo() {
       </label>
       <PriceInput />
       <div className="mt-6">
-        <TagBox />
+        <TagSection />
       </div>
       <div className="mt-6">
         <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">

--- a/src/components/recruitment-create/tag-ui/SelectedTagSection.tsx
+++ b/src/components/recruitment-create/tag-ui/SelectedTagSection.tsx
@@ -1,0 +1,45 @@
+import SelectedTagList from '@src/components/commons/tag/SelectedTagList'
+import type { Tag } from '@src/types/tag'
+import { useMemo } from 'react'
+
+interface SelectedTagSectionProps {
+  selected: Tag[]
+  max: number
+  items: Tag[]
+  onRemove: (id: number) => void
+}
+
+export default function SelectedTagSection({
+  selected,
+  max,
+  items,
+  onRemove,
+}: SelectedTagSectionProps) {
+  const selectedIds = useMemo(() => selected.map((t) => t.id), [selected])
+  const options = useMemo(
+    () =>
+      [...selected, ...(items ?? [])].map((t) => ({
+        id: t.id,
+        label: t.name,
+      })),
+    [selected, items]
+  )
+  return (
+    <div className="px-6 py-3">
+      <p className="mb-3 text-sm">
+        선택된 태그 ({selected.length}/{max})
+      </p>
+      {selectedIds.length > 0 ? (
+        <SelectedTagList
+          selectedIds={selectedIds}
+          options={options}
+          onRemove={onRemove}
+        />
+      ) : (
+        <p className="text-xs font-light text-gray-400">
+          선택된 태그가 없습니다
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/recruitment-create/tag-ui/TagBox.tsx
+++ b/src/components/recruitment-create/tag-ui/TagBox.tsx
@@ -1,18 +1,14 @@
 import Button from '@src/components/commons/button/Button'
 import { EmptyState } from '@src/components/commons/EmptyState'
 import SelectedTagList from '@src/components/commons/tag/SelectedTagList'
+import type { Tag } from '@src/types/tag'
 import { cn } from '@src/utils/cn'
 import { Plus } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 
-export interface Tag {
-  id: number
-  name: string
-}
-
 export interface TagBoxProps {
   value?: Tag[] // 선택된 태그 목록
-  onChange?: (next: Tag[]) => void // 변경 콜백
+  onChange?: React.Dispatch<React.SetStateAction<Tag[]>> // 변경 콜백
   max?: number // 최대 선택 가능 개수 기본 5
   title?: string // 기본 '사용자 정의 태그'
   onOpenSearch?: () => void // 모달 연결
@@ -25,36 +21,28 @@ export default function TagBox({
   title = '사용자 정의 태그',
   onOpenSearch,
 }: TagBoxProps) {
-  const [inner, setInner] = useState<Tag[]>([
-    // 더미데이터
-    { id: 1, name: '초보자환영' },
-    { id: 2, name: '주말스터디' },
-    { id: 3, name: '프로젝트중심' },
-  ])
-
+  const [inner, setInner] = useState<Tag[]>([])
   const tags = value ?? inner //현재 TagBox가 관리할 실제 태그 목록
   const setTags = onChange ?? setInner //태그 목록을 변경
-  const countText = useMemo(() => `(${tags.length}/${max})`, [tags.length, max]) // 현재 태그 개수와 최대 개수를 문자열로 표시
-  const selectedIds = useMemo(() => tags.map((t) => String(t.id)), [tags]) // 현재 선택된 태그들의 id 목록
 
-  const options = useMemo(
-    () => tags.map((tag) => ({ id: String(tag.id), label: tag.name })),
-    [tags]
+  const removeById = useCallback(
+    (id: number) => {
+      const targetId = Number(id)
+      setTags((prev) => prev.filter((tag) => tag.id !== targetId))
+    },
+    [setTags]
   )
 
-  // 태그 삭제 처리
-  const removeById = useCallback(
-    (idStr: string) => {
-      const idNum = Number(idStr)
-      setTags(tags.filter((tag) => tag.id !== idNum))
-    },
-    [tags, setTags]
+  const selectedIds = useMemo(() => tags.map((t) => t.id), [tags])
+  const options = useMemo(
+    () => tags.map((t) => ({ id: t.id, label: t.name })),
+    [tags]
   )
 
   return (
     <div className="space-y-2">
       <div className="flex items-start justify-between">
-        <span className="text-md font-medium text-gray-900">{title}</span>
+        <span className="text-sm font-medium text-gray-900">{title}</span>
         <Button
           size="base"
           buttonInnerText="태그 검색"
@@ -65,10 +53,10 @@ export default function TagBox({
       </div>
       <div
         className={cn(
-          'rounded-sm border-2 px-4 py-6',
+          'rounded-xl border-2 px-4 py-6',
           tags.length === 0
             ? 'border-dashed border-gray-300'
-            : 'border border-gray-300 bg-gray-100'
+            : 'border-gray-300 bg-gray-100'
         )}
       >
         <div
@@ -81,9 +69,9 @@ export default function TagBox({
             <EmptyState
               title="선택된 태그가 없습니다."
               iconType="TAG"
-              titleClassName="text-gray-500 pb-0"
+              titleClassName="text-gray-500 pb-0 text-sm"
               description="태그 검색 버튼을 클릭해서 태그를 추가해 보세요"
-              descClassName="text-md"
+              descClassName="text-xs"
               iconSize="lg"
               size="sm"
             />
@@ -97,7 +85,7 @@ export default function TagBox({
         </div>
       </div>
       <p className="text-xs text-gray-500">
-        태그는 최대 {max}개까지 선택할 수 있습니다 {countText}
+        태그는 최대 {max}개까지 선택할 수 있습니다 ({tags.length}/{max})
       </p>
     </div>
   )

--- a/src/components/recruitment-create/tag-ui/TagBox.tsx
+++ b/src/components/recruitment-create/tag-ui/TagBox.tsx
@@ -11,11 +11,11 @@ export interface Tag {
 }
 
 export interface TagBoxProps {
-  value?: Tag[] // 선택 (선택)
-  onChange?: (next: Tag[]) => void // 변경 콜백 (선택)
-  max?: number // 기본 5
+  value?: Tag[] // 선택된 태그 목록
+  onChange?: (next: Tag[]) => void // 변경 콜백
+  max?: number // 최대 선택 가능 개수 기본 5
   title?: string // 기본 '사용자 정의 태그'
-  onOpenSearch?: () => void // (옵션) 모달 연결
+  onOpenSearch?: () => void // 모달 연결
 }
 
 export default function TagBox({

--- a/src/components/recruitment-create/tag-ui/TagCreateBox.tsx
+++ b/src/components/recruitment-create/tag-ui/TagCreateBox.tsx
@@ -1,0 +1,45 @@
+import Button from '@src/components/commons/button/Button'
+import { EmptyState } from '@src/components/commons/EmptyState'
+
+interface TagCreateBoxProps {
+  value: string
+  onCreate?: (name: string) => Promise<void> | void
+  loading?: boolean
+}
+export default function TagCreateBox({
+  value,
+  onCreate,
+  loading,
+}: TagCreateBoxProps) {
+  const handleClick = async () => {
+    await onCreate?.(value.trim())
+  }
+  return (
+    <div className="flex h-full w-full flex-1 flex-col">
+      <EmptyState
+        iconType="TAG"
+        iconClassName="text-gray-400"
+        description="다른 키워드로 검색하거나 새 태그를 등록해 보세요"
+        iconContainerClassName="bg-gray-100 rounded-full w-14 h-14 flex items-center mb-3"
+        descClassName="text-sm"
+        titleClassName="text-gray-800 font-medium text-md"
+        wrapperClassName="flex-1 p-0"
+      />
+      <div className="border-primary-300 bg-primary-50/80 flex items-start justify-between rounded-xl border-2 border-dashed p-4">
+        <div>
+          <p className="text-primary-900 pb-1 text-sm font-medium tracking-wider">
+            {`'${value}'`} 태그를 새로 만드시겠습니까?
+          </p>
+          <p className="text-primary-600 text-xs">
+            검색 결과에 원하는 태그가 없는 경우 새로 등록할 수 있습니다.
+          </p>
+        </div>
+        <Button
+          buttonInnerText={loading ? '...등록중' : '새로 등록하기'}
+          onClick={handleClick}
+          disabled={loading || !value.trim()}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/recruitment-create/tag-ui/TagResultSection.tsx
+++ b/src/components/recruitment-create/tag-ui/TagResultSection.tsx
@@ -1,0 +1,58 @@
+import LoadingSpinner from '@src/components/commons/LoadingSpinner'
+import type { Tag } from '@src/types/tag'
+import TagCreateBox from './TagCreateBox'
+import TagCheckbox from '@src/components/commons/tag/TagCheckbox'
+import { cn } from '@src/utils/cn'
+
+interface TagResultSectionProps {
+  items: Tag[]
+  loading: boolean
+  query: string
+  creating: boolean
+  justCreatedId: number | null
+  isSelected: (id: number) => boolean
+  toggle: (tag: Tag, nextChecked: boolean) => void
+  atMax: boolean
+  onCreate: (name: string) => void
+}
+
+export default function TagResultSection({
+  items,
+  loading,
+  query,
+  creating,
+  justCreatedId,
+  isSelected,
+  toggle,
+  atMax,
+  onCreate,
+}: TagResultSectionProps) {
+  return (
+    <div className="flex h-[290px] w-full flex-col items-start gap-2 px-6">
+      {loading ? (
+        <div className="flex h-[290px] w-full items-center justify-center">
+          <LoadingSpinner message="태그 검색 중..." className="bg-white" />
+        </div>
+      ) : items.length === 0 ? (
+        <TagCreateBox value={query} onCreate={onCreate} loading={creating} />
+      ) : (
+        items.map((tag) => (
+          <TagCheckbox
+            key={tag.id}
+            label={tag.name}
+            checked={isSelected(tag.id)}
+            onChange={(checked) => toggle(tag, checked)}
+            className={cn(
+              !isSelected(tag.id) && atMax
+                ? 'cursor-not-allowed opacity-50'
+                : '',
+              tag.id === justCreatedId
+                ? 'ring-success-500 bg-success-100 animate-pulse ring-2'
+                : ''
+            )}
+          />
+        ))
+      )}
+    </div>
+  )
+}

--- a/src/components/recruitment-create/tag-ui/TagSearchModal.tsx
+++ b/src/components/recruitment-create/tag-ui/TagSearchModal.tsx
@@ -1,0 +1,3 @@
+export default function TagSearchModal() {
+  return
+}

--- a/src/components/recruitment-create/tag-ui/TagSearchModal.tsx
+++ b/src/components/recruitment-create/tag-ui/TagSearchModal.tsx
@@ -1,3 +1,35 @@
-export default function TagSearchModal() {
-  return
+import Button from '@src/components/commons/button/Button'
+import Modal from '@src/components/commons/modal'
+
+interface TagSearchModalProps {
+  open: boolean
+  onClose: () => void
+  title?: string
+}
+
+export default function TagSearchModal({ open, onClose }: TagSearchModalProps) {
+  return (
+    <Modal open={open} onClose={onClose} size="md" closeOnOutsideClick={false}>
+      <Modal.Header onClose={onClose}>
+        <h2 className="truncate text-xl font-semibold text-gray-900">
+          태그선택
+        </h2>
+      </Modal.Header>
+      <Modal.Footer>
+        <div className="text-sm text-gray-500">태그 n개 선택됨</div>
+        <div className="flex items-center gap-2">
+          <Button buttonInnerText="취소" variant="outline" onClick={onClose} />
+          <Button
+            buttonInnerText="선택완료"
+            variant="primary"
+            size="base"
+            fontWeight="medium"
+            iconClassName="rotate-[90deg]"
+            onClick={onClose}
+            iconSize="sm"
+          />
+        </div>
+      </Modal.Footer>
+    </Modal>
+  )
 }

--- a/src/components/recruitment-create/tag-ui/TagSearchModal.tsx
+++ b/src/components/recruitment-create/tag-ui/TagSearchModal.tsx
@@ -1,31 +1,144 @@
 import Button from '@src/components/commons/button/Button'
 import Modal from '@src/components/commons/modal'
+import { useCallback, useEffect } from 'react'
+import { SearchBar } from '@src/components/commons/SearchBar'
+import Pagination from '@src/components/commons/pagination/Pagination'
+import type { Tag } from '@src/types/tag'
+import { useTagManager } from '@src/hooks/tag/useTagManager'
+import { useSelectedTags } from '@src/hooks/tag/useSelectedTags'
+import SelectedTagSection from './SelectedTagSection'
+import TagResultSection from './TagResultSection'
 
 interface TagSearchModalProps {
   open: boolean
   onClose: () => void
+  onSubmit?: (next: Tag[]) => void
   title?: string
+  initialSelected?: Tag[]
+  max?: number
+  size?: number
 }
 
-export default function TagSearchModal({ open, onClose }: TagSearchModalProps) {
+export default function TagSearchModal({
+  open,
+  onClose,
+  onSubmit,
+  title = '태그 선택',
+  initialSelected = [],
+  max = 5,
+  size = 5,
+}: TagSearchModalProps) {
+  const {
+    query,
+    setQuery,
+    page,
+    setPage,
+    items,
+    count,
+    loading,
+    creating,
+    justCreatedId,
+    register, // 새 태그 등록
+  } = useTagManager(open, size) // 검색/페이지네이션/등록
+
+  // 선택 상태 관리
+  const { selected, setSelected, atMax, isSelected, toggle, removeById } =
+    useSelectedTags(initialSelected, max)
+
+  const handleConfirm = () => {
+    onSubmit?.(selected)
+    setQuery('')
+    onClose()
+  }
+
+  const handleSearch = useCallback(
+    (keyword: string) => {
+      setQuery((prev) => (prev === keyword ? prev : keyword))
+      setPage(1)
+    },
+    [setQuery, setPage]
+  )
+
+  const handleCreate = useCallback(
+    async (name: string) => {
+      await register(name) // 반환된 Tag는 쓰지 않음 => Promise<void>로 취급
+    },
+    [register]
+  )
+
+  useEffect(() => {
+    if (!open) return
+    setSelected(initialSelected)
+    setPage(1)
+  }, [open, initialSelected, setPage])
+
+  const handleClose = () => {
+    setQuery('')
+    onClose()
+  }
+
   return (
     <Modal open={open} onClose={onClose} size="md" closeOnOutsideClick={false}>
-      <Modal.Header onClose={onClose}>
+      <Modal.Header onClose={handleClose}>
         <h2 className="truncate text-xl font-semibold text-gray-900">
-          태그선택
+          {title}
         </h2>
+        <p className="mt-1 text-sm text-gray-500">
+          공고에 추가할 태그를 선택하세요. (최대 5개)
+        </p>
       </Modal.Header>
+      <div className="min-h-0 flex-1 gap-3 overflow-y-auto">
+        <div className="relative w-full px-6 py-3">
+          <SearchBar
+            value={query}
+            onSearch={handleSearch}
+            placeholder="태그명으로 검색..."
+            className="m-0 w-full"
+            delay={300}
+          />
+        </div>
+        {/* 섵택된 태그 리스트 */}
+        <SelectedTagSection
+          selected={selected}
+          max={max}
+          items={items}
+          onRemove={(id) => removeById(Number(id))}
+        />
+        {/* 결과 체크박스 리스트 */}
+        <TagResultSection
+          items={items}
+          loading={loading}
+          query={query}
+          creating={creating}
+          justCreatedId={justCreatedId}
+          isSelected={isSelected}
+          toggle={toggle}
+          atMax={atMax}
+          onCreate={handleCreate}
+        />
+        {/* 페이지네이션 */}
+        <Pagination
+          page={page}
+          totalCount={count}
+          size={size}
+          onPageChange={setPage}
+          className=""
+        />
+      </div>
       <Modal.Footer>
-        <div className="text-sm text-gray-500">태그 n개 선택됨</div>
-        <div className="flex items-center gap-2">
-          <Button buttonInnerText="취소" variant="outline" onClick={onClose} />
+        <div className="ml-auto flex gap-2">
+          <Button
+            buttonInnerText="취소"
+            variant="outline"
+            onClick={handleClose}
+          />
           <Button
             buttonInnerText="선택완료"
             variant="primary"
             size="base"
             fontWeight="medium"
             iconClassName="rotate-[90deg]"
-            onClick={onClose}
+            onClick={handleConfirm}
             iconSize="sm"
           />
         </div>

--- a/src/components/recruitment-create/tag-ui/TagSection.tsx
+++ b/src/components/recruitment-create/tag-ui/TagSection.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import TagBox from './TagBox'
+import TagSearchModal from './TagSearchModal'
+import type { Tag } from '@src/types/tag'
+
+export default function TagSection() {
+  const [tags, setTags] = useState<Tag[]>([])
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <TagBox
+        value={tags}
+        onChange={setTags}
+        onOpenSearch={() => setOpen(true)}
+      />
+      <TagSearchModal
+        open={open}
+        onClose={() => setOpen(false)}
+        onSubmit={setTags}
+        initialSelected={tags}
+        max={5}
+      />
+    </>
+  )
+}

--- a/src/components/recruitment-manage/application/ApplicationModal.tsx
+++ b/src/components/recruitment-manage/application/ApplicationModal.tsx
@@ -64,7 +64,8 @@ export default function ApplicationModal({
     reset,
     clearErrors,
     setValue,
-    formState: { errors, isValid, isSubmitting },
+    setFocus,
+    formState: { errors },
   } = useForm<Form>({ mode: 'onChange' })
 
   const hasExp = watch('hasExp') ?? false
@@ -73,6 +74,15 @@ export default function ApplicationModal({
     console.log(data)
     reset()
     onClose()
+  }
+  const onInvalid = () => {
+    const firstErrorName = Object.keys(errors)[0] as keyof Form | undefined
+    if (!firstErrorName) return
+
+    setFocus(firstErrorName, { shouldSelect: true })
+
+    const el = document.getElementById(String(firstErrorName))
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }
 
   const handleClose = () => {
@@ -94,6 +104,7 @@ export default function ApplicationModal({
       onClose={handleClose}
       size="md"
       closeOnOutsideClick={false}
+      className="max-h-[100vh]"
     >
       <Modal.Header onClose={handleClose}>
         <h2 className="truncate text-xl font-semibold text-gray-900">
@@ -102,7 +113,7 @@ export default function ApplicationModal({
         <p className="mt-1 text-sm text-gray-500">{title}</p>
       </Modal.Header>
 
-      <div className="max-h-[80vh] min-h-0 flex-1 space-y-6 overflow-y-auto px-10 py-4">
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-10 py-4">
         {/* 반복되는 텍스트영역 map */}
         {TEXT_FIELDS.map(({ name, label, placeholder }) => {
           const value = (watch(name) as string) ?? ''
@@ -179,8 +190,7 @@ export default function ApplicationModal({
             size="base"
             fontWeight="medium"
             iconClassName="rotate-[90deg]"
-            disabled={!isValid || isSubmitting}
-            onClick={handleSubmit(onSubmit)}
+            onClick={handleSubmit(onSubmit, onInvalid)}
             iconSize="sm"
           />
         </div>

--- a/src/hooks/tag/useSelectedTags.ts
+++ b/src/hooks/tag/useSelectedTags.ts
@@ -1,0 +1,48 @@
+import { useState, useCallback, useEffect } from 'react'
+import type { Tag } from '@src/types/tag'
+
+export function useSelectedTags(initial: Tag[] = [], max = 5) {
+  const [selected, setSelected] = useState<Tag[]>(initial)
+
+  // initial 값이 바뀌면 동기화 (모달 열릴 때 부모가 넘겨준 최신 선택 반영)
+  useEffect(() => {
+    setSelected(initial)
+  }, [initial])
+
+  const isSelected = useCallback(
+    (id: number) => selected.some((t) => t.id === id),
+    [selected]
+  )
+
+  const toggle = useCallback(
+    (tag: Tag, nextChecked: boolean) => {
+      setSelected((prev) => {
+        if (nextChecked) {
+          if (prev.some((t) => t.id === tag.id)) return prev
+          if (prev.length >= max) return prev // 최신 prev 길이로 판단
+          return [...prev, tag]
+        }
+        return prev.filter((t) => t.id !== tag.id)
+      })
+    },
+    [max]
+  )
+
+  const removeById = useCallback((id: number) => {
+    setSelected((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const clear = useCallback(() => setSelected([]), [])
+  const setMany = useCallback((tags: Tag[]) => setSelected(tags), [])
+
+  return {
+    selected,
+    setSelected,
+    isSelected,
+    toggle,
+    removeById,
+    clear,
+    setMany,
+    atMax: selected.length >= max,
+  }
+}

--- a/src/hooks/tag/useTagManager.ts
+++ b/src/hooks/tag/useTagManager.ts
@@ -1,0 +1,100 @@
+import { useEffect, useState, useCallback } from 'react'
+import type { Tag } from '@src/types/tag'
+import { createTag, fetchTags } from '@src/api/tag'
+import { useToast } from '@src/components/commons/toast'
+import axios from 'axios'
+import { checkTagValidity } from '@src/validations/tag'
+
+export function useTagManager(open: boolean, pageSize = 5) {
+  const toast = useToast()
+  const [query, setQuery] = useState('') // 검색어
+  const [page, setPage] = useState(1) // 현재 페이지
+  const [items, setItems] = useState<Tag[]>([]) // 검색 결과
+  const [count, setCount] = useState(0) // 총 개수
+  const [loading, setLoading] = useState(false) // 로딩중인지
+  const [creating, setCreating] = useState(false) // 새 태그 등록중인지
+  const [justCreatedId, setJustCreatedId] = useState<number | null>(null) //새등록 태그 ID 임시 저장 => 등록된 상태 에니메이션을 위함
+
+  const fetchAndSetTags = useCallback(async () => {
+    if (!open) return
+    setLoading(true)
+    try {
+      const { results, count } = await fetchTags({
+        search: query, // 검색어
+        page, // 현재 페이지 번호
+        size: pageSize, // 페이지당 항목 개수
+      })
+      setItems(Array.isArray(results) ? results : []) // 받아온 태그 리스트를 상태에 저장
+      setCount(typeof count === 'number' ? count : 0) // 전체 태그 개수를 상태에 저장 (페이지네이션용)
+    } catch (error) {
+      setItems([])
+      setCount(0)
+      toast.error({
+        title: '태그 불러오기 실패',
+        content: '잠시 후 다시 시도해 주세요.',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [open, query, page, pageSize, toast])
+
+  // open, query, page 변경 시 실행
+  useEffect(() => {
+    fetchAndSetTags()
+  }, [fetchAndSetTags])
+
+  const register = useCallback(
+    async (name: string) => {
+      const trimmed = name.trim()
+      const msg = checkTagValidity(trimmed)
+      if (msg) {
+        toast.warning({ title: '태그 등록 실패', content: msg })
+        throw new Error('validation_failed')
+      }
+      setCreating(true)
+      try {
+        const tag = await createTag(name.trim()) // 새 태그 생성 POST 200 OK { id, name } 반환
+        setJustCreatedId(tag.id) // 새 등록된 태그 ID 임시 저장
+        setQuery(tag.name) // 생성된 태그 이름으로 검색어 자동 등록
+        await fetchAndSetTags() // 목록 즉시 갱신
+        toast.success({
+          title: '태그 등록 완료',
+          content: `${tag.name} 태그가 등록되었습니다. 목록에서 선택해 주세요.`,
+        })
+        return tag
+      } catch (e: unknown) {
+        // 서버 에러
+        if (axios.isAxiosError(e)) {
+          if (e?.response?.status === 409) {
+            toast.warning({
+              title: '태그 등록 실패',
+              content: `이미 존재하는 태그예요. 목록에서 선택해 주세요.`,
+            })
+          } else {
+            toast.error({
+              title: '태그 등록 실패',
+              content: '잠시 후 다시 시도해 주세요.',
+            })
+          }
+        }
+      } finally {
+        setCreating(false)
+        setTimeout(() => setJustCreatedId(null), 2000)
+      }
+    },
+    [fetchAndSetTags, toast]
+  )
+
+  return {
+    query,
+    setQuery,
+    page,
+    setPage,
+    items,
+    count,
+    loading,
+    creating,
+    justCreatedId,
+    register,
+  }
+}

--- a/src/mock/browser.ts
+++ b/src/mock/browser.ts
@@ -1,4 +1,4 @@
-import { setupWorker } from 'msw/browser';
-import { handlers } from './handler';
+import { setupWorker } from 'msw/browser'
+import { handlers } from './handlers'
 
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...handlers)

--- a/src/mock/handlers/index.ts
+++ b/src/mock/handlers/index.ts
@@ -1,0 +1,4 @@
+import { notificationHandlers } from './notifications'
+import { tagHandlers } from './tags'
+
+export const handlers = [...notificationHandlers, ...tagHandlers]

--- a/src/mock/handlers/notifications.ts
+++ b/src/mock/handlers/notifications.ts
@@ -1,12 +1,13 @@
 // src/mocks/handlers.ts
 import { http, HttpResponse } from 'msw'
-import notificationsData from './notificationsData'
 import type {
   NotificationItem,
   NotificationResponse,
 } from '@src/types/notification'
+
 import type { Chat } from '@src/types/chat'
-import chatMessagesData, { chatList } from './chatListData'
+import chatMessagesData, { chatList } from '../chatListData'
+import notificationsData from '../notificationsData'
 
 // 변경 가능한 데이터 선언
 let mutableNotificationsData: NotificationItem[] = [...notificationsData]
@@ -46,7 +47,7 @@ const validateAuth = (request: Request) => {
   return { isValid: true }
 }
 
-export const handlers = [
+export const notificationHandlers = [
   // 전체 알림 목록 조회 API 모킹
   http.get('/api/v1/notifications', ({ request }) => {
     const auth = validateAuth(request)

--- a/src/mock/handlers/tags.ts
+++ b/src/mock/handlers/tags.ts
@@ -1,0 +1,106 @@
+import { http, HttpResponse } from 'msw'
+import type { Tag } from '@src/types/tag'
+
+// 간단 인메모리
+let seq = 100
+const tagsDb: Tag[] = [
+  { id: 1, name: 'Python' },
+  { id: 2, name: 'React' },
+  { id: 3, name: 'TypeScript' },
+  { id: 4, name: 'Spring' },
+  { id: 5, name: 'Django' },
+  { id: 6, name: 'Vue.js' },
+  { id: 7, name: 'Angular' },
+  { id: 8, name: 'Node.js' },
+  { id: 9, name: 'Express' },
+  { id: 10, name: 'MongoDB' },
+  { id: 11, name: 'SQL' },
+  { id: 12, name: 'Java' },
+  { id: 13, name: 'C++' },
+  { id: 14, name: 'C#' },
+  { id: 15, name: 'Go' },
+  { id: 16, name: 'Rust' },
+  { id: 17, name: 'Kotlin' },
+  { id: 18, name: 'Swift' },
+  { id: 19, name: 'Machine Learning' },
+  { id: 20, name: 'Data Science' },
+  { id: 21, name: 'AI' },
+  { id: 22, name: 'Docker' },
+  { id: 23, name: 'Kubernetes' },
+  { id: 24, name: 'AWS' },
+  { id: 25, name: 'Azure' },
+  { id: 26, name: 'GCP' },
+  { id: 27, name: 'Front-end' },
+  { id: 28, name: 'Back-end' },
+  { id: 29, name: 'Full-stack' },
+  { id: 30, name: 'iOS' },
+  { id: 31, name: 'Android' },
+  { id: 32, name: '초보자환영' },
+  { id: 33, name: '주말스터디' },
+  { id: 34, name: '온라인' },
+  { id: 35, name: '오프라인' },
+  { id: 36, name: '스터디' },
+  { id: 37, name: '프로젝트' },
+  { id: 38, name: '디자인' },
+  { id: 39, name: 'UX/UI' },
+  { id: 40, name: 'Figma' },
+  { id: 41, name: 'Photoshop' },
+  { id: 42, name: 'Illustrator' },
+  { id: 43, name: 'HTML' },
+  { id: 44, name: 'CSS' },
+  { id: 45, name: 'JavaScript' },
+  { id: 46, name: 'Git' },
+  { id: 47, name: 'Scrum' },
+  { id: 48, name: 'Agile' },
+  { id: 49, name: 'Jira' },
+  { id: 50, name: '피그마' },
+]
+
+const compareByName = (a: Tag, b: Tag) => a.name.localeCompare(b.name, 'ko')
+
+const paginate = <T>(arr: T[], page: number, size: number) => {
+  const start = (page - 1) * size
+  return arr.slice(start, start + size)
+}
+
+// 검색 + 페이지네이션
+export const tagHandlers = [
+  http.get('/api/v1/recruitments/tags', ({ request }) => {
+    const url = new URL(request.url)
+    const search = (url.searchParams.get('search') || '').trim().toLowerCase()
+    const page = parseInt(url.searchParams.get('page') || '1', 10)
+    const size = parseInt(url.searchParams.get('size') || '10', 10)
+
+    const filtered = tagsDb
+      .filter((t) => t.name.toLowerCase().includes(search))
+      .sort(compareByName)
+
+    const results = paginate(filtered, page, size)
+    const body = { results, count: filtered.length }
+
+    return HttpResponse.json(body, { status: 200 })
+  }),
+
+  // 새 태그 등록 (중복시 409)
+  http.post('/api/v1/recruitments/tags', async ({ request }) => {
+    const body = await request.json().catch(() => ({}) as any)
+    const name = (body?.name ?? '').trim()
+    if (!name) {
+      return HttpResponse.json({ detail: 'name is required' }, { status: 400 })
+    }
+
+    const exists = tagsDb.some(
+      (t) => t.name.toLowerCase() === name.toLowerCase()
+    )
+    if (exists) {
+      return HttpResponse.json(
+        { detail: 'Tag already exists' },
+        { status: 409 }
+      )
+    }
+
+    const tag: Tag = { id: ++seq, name }
+    tagsDb.unshift(tag) // 최신 우선
+    return HttpResponse.json(tag, { status: 201 })
+  }),
+]

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -57,7 +57,11 @@ export default function CoursesPage({ className }: CoursesPageProps) {
   })
 
   if (loading) {
-    return <LoadingSpinner message={LOADING_MESSAGES.COURSES} />
+    return (
+      <div className="h-screen w-full">
+        <LoadingSpinner message={LOADING_MESSAGES.COURSES} />
+      </div>
+    )
   }
 
   if (error) {

--- a/src/pages/test-page/TestUIPage.tsx
+++ b/src/pages/test-page/TestUIPage.tsx
@@ -13,23 +13,12 @@ import {
 import { useState } from 'react'
 import Calendar from '@src/components/commons/calendar/Calendar'
 import { useToast } from '@src/components/commons/toast'
-import TagCheckbox from '@src/components/commons/tag/TagCheckbox'
-import type { TagOption } from '@src/components/commons/tag/SelectedTagList'
-import SelectedTagList from '@src/components/commons/tag/SelectedTagList'
 import Pagination from '@src/components/commons/pagination/Pagination'
 
 export default function TestUIPage() {
   const [selectedCategory, setSelectedCategory] = useState('전체')
   const [selectedSort, setSelectedSort] = useState('인기순')
   const toast = useToast()
-  const [selectedIds, setSelectedIds] = useState<string[]>(['t1'])
-
-  // 임시 데이터 (나중에 상수로 분리)
-  const dummyTags: TagOption[] = [
-    { id: 't1', label: '초보자환영' },
-    { id: 't2', label: '주말스터디' },
-    { id: 't3', label: '프로젝트중심' },
-  ]
 
   //페이지네이션 임시 변수
   const [page, setPage] = useState(1)
@@ -94,169 +83,140 @@ export default function TestUIPage() {
   const [date, setDate] = useState<Date | null>(null)
   return (
     <div className="space-y-4 p-4">
-        {/* 선택 가능한 드롭다운 */}
-        <DropDown
-          selected={selectedCategory}
-          options={categories}
-          onSelect={setSelectedCategory}
-          leftIcon={FolderIcon}
-          placeholder="카테고리 선택"
-        />
-        {/* 정렬 드롭다운 */}
-        <DropDown
-          selected={selectedSort}
-          options={sortOptions}
-          onSelect={setSelectedSort}
-          placeholder="정렬 선택"
-        />
+      {/* 선택 가능한 드롭다운 */}
+      <DropDown
+        selected={selectedCategory}
+        options={categories}
+        onSelect={setSelectedCategory}
+        leftIcon={FolderIcon}
+        placeholder="카테고리 선택"
+      />
+      {/* 정렬 드롭다운 */}
+      <DropDown
+        selected={selectedSort}
+        options={sortOptions}
+        onSelect={setSelectedSort}
+        placeholder="정렬 선택"
+      />
 
-        {/* 비활성화된 드롭다운 */}
-        <DropDown
-          selected="비활성화됨"
-          options={[]}
-          disabled
-          className="w-fit"
-        />
+      {/* 비활성화된 드롭다운 */}
+      <DropDown selected="비활성화됨" options={[]} disabled className="w-fit" />
 
-        {/* 페이지 링크 */}
-        <PageLink
-          link="/"
-          pageLinkInnerText="로그인 후 공고 작성"
-          icon={LogInIcon}
-        />
-        <PageLink
-          link="/"
-          pageLinkInnerText="지원하기"
-          icon={MousePointer2Icon}
-          iconClassName="rotate-[90deg]"
-        />
-        <PageLink
-          link="/"
-          pageLinkInnerText="회원가입하기"
-          icon={UserRoundPlusIcon}
-          variant="outline"
-          fontWeight="medium"
-        />
+      {/* 페이지 링크 */}
+      <PageLink
+        link="/"
+        pageLinkInnerText="로그인 후 공고 작성"
+        icon={LogInIcon}
+      />
+      <PageLink
+        link="/"
+        pageLinkInnerText="지원하기"
+        icon={MousePointer2Icon}
+        iconClassName="rotate-[90deg]"
+      />
+      <PageLink
+        link="/"
+        pageLinkInnerText="회원가입하기"
+        icon={UserRoundPlusIcon}
+        variant="outline"
+        fontWeight="medium"
+      />
 
-        {/* 버튼 */}
-        <Button
-          buttonInnerText="지원서 제출"
-          icon={MousePointer2Icon}
-          iconClassName="rotate-[90deg]"
-          size="base"
-          iconSize="sm"
-        />
-        <Button buttonInnerText="취소" size="base" variant="outline" />
-        <Button
-          buttonInnerText="거절"
-          size="base"
-          iconSize="sm"
-          variant="danger"
-          icon={CloseIcon}
-        />
-        <Button
-          buttonInnerText="선택 완료"
-          size="base"
-          variant="outline"
-          disabled
-        />
+      {/* 버튼 */}
+      <Button
+        buttonInnerText="지원서 제출"
+        icon={MousePointer2Icon}
+        iconClassName="rotate-[90deg]"
+        size="base"
+        iconSize="sm"
+      />
+      <Button buttonInnerText="취소" size="base" variant="outline" />
+      <Button
+        buttonInnerText="거절"
+        size="base"
+        iconSize="sm"
+        variant="danger"
+        icon={CloseIcon}
+      />
+      <Button
+        buttonInnerText="선택 완료"
+        size="base"
+        variant="outline"
+        disabled
+      />
 
-        <Button
-          icon={BookmarkIcon}
-          variant="outline"
-          iconButtonSize="lg"
-          ariaLabel="북마크"
-          iconClassName="stroke-gray-600"
-          className="rounded-lg bg-white"
-        />
+      <Button
+        icon={BookmarkIcon}
+        variant="outline"
+        iconButtonSize="lg"
+        ariaLabel="북마크"
+        iconClassName="stroke-gray-600"
+        className="rounded-lg bg-white"
+      />
 
-        <Button
-          icon={BookmarkIcon}
-          variant="ghost"
-          iconButtonSize="md"
-          ariaLabel="북마크"
-          iconClassName="stroke-gray-600"
-          className="bg-white/90"
-        />
+      <Button
+        icon={BookmarkIcon}
+        variant="ghost"
+        iconButtonSize="md"
+        ariaLabel="북마크"
+        iconClassName="stroke-gray-600"
+        className="bg-white/90"
+      />
 
-        {/* 뱃지 */}
-        <Badge badgeTitle="거절됨" className="bg-danger-100 text-danger-800" />
+      {/* 뱃지 */}
+      <Badge badgeTitle="거절됨" className="bg-danger-100 text-danger-800" />
 
-        <Button
-          buttonInnerText="성공 토스트"
-          onClick={() =>
-            toast.success({
-              title: '성공적으로 저잘되었습니다.',
-              content: '변경사항이 성공적으로 적용되었습니다.',
-              showBar: true,
-            })
-          }
-        />
-        {/* 토스트 알림 컴포넌트 태스트 */}
-        <Button
-          buttonInnerText="에러 토스트"
-          onClick={() =>
-            toast.error({
-              title: '주의가 필요합니다.',
-              content: '일부 정보가 누락되었습니다. 확인 후 다시 시도해주세요.',
-              showBar: true,
-            })
-          }
-        />
-        <Button
-          buttonInnerText="경고 토스트"
-          onClick={() =>
-            toast.warning({
-              title: '오류가 발생했습니다.',
-              content: '네트워크 연결을 확인하고 다시 시도해주세요.',
+      <Button
+        buttonInnerText="성공 토스트"
+        onClick={() =>
+          toast.success({
+            title: '성공적으로 저잘되었습니다.',
+            content: '변경사항이 성공적으로 적용되었습니다.',
+            showBar: true,
+          })
+        }
+      />
+      {/* 토스트 알림 컴포넌트 태스트 */}
+      <Button
+        buttonInnerText="에러 토스트"
+        onClick={() =>
+          toast.error({
+            title: '주의가 필요합니다.',
+            content: '일부 정보가 누락되었습니다. 확인 후 다시 시도해주세요.',
+            showBar: true,
+          })
+        }
+      />
+      <Button
+        buttonInnerText="경고 토스트"
+        onClick={() =>
+          toast.warning({
+            title: '오류가 발생했습니다.',
+            content: '네트워크 연결을 확인하고 다시 시도해주세요.',
 
-              showBar: true,
-            })
-          }
-        />
-        <Calendar
-          value={date}
-          onChange={setDate}
-          variant="outline"
-          size="md"
-          width={300}
-        />
+            showBar: true,
+          })
+        }
+      />
+      <Calendar
+        value={date}
+        onChange={setDate}
+        variant="outline"
+        size="md"
+        width={300}
+      />
 
-        {/* 태그 선택 컴포넌트 테스트 */}
+      {/* 태그 선택 컴포넌트 테스트 */}
 
-        <h2 className="text-lg font-bold">Tag 컴포넌트 테스트</h2>
+      <h2 className="text-lg font-bold">Tag 컴포넌트 테스트</h2>
 
-        {/* 선택된 태그 리스트 */}
-        <SelectedTagList
-          selectedIds={selectedIds}
-          options={dummyTags}
-          onRemove={(id) =>
-            setSelectedIds((prev) => prev.filter((v) => v !== id))
-          }
-        />
-
-        {/* 체크박스 리스트 */}
-        <div className="space-y-2">
-          {dummyTags.map((tag) => (
-            <TagCheckbox
-              key={tag.id}
-              label={tag.label}
-              checked={selectedIds.includes(tag.id)}
-              onChange={(next) =>
-                setSelectedIds((prev) =>
-                  next ? [...prev, tag.id] : prev.filter((v) => v !== tag.id)
-                )
-              }
-            />
-          ))}
-        </div>
-        {/* 페이지 네이션 테스트  */}
-        <Pagination
-          page={page}
-          totalCount={totalCount}
-          size={size}
-          onPageChange={setPage}
-        />
-      </div>
+      {/* 페이지 네이션 테스트  */}
+      <Pagination
+        page={page}
+        totalCount={totalCount}
+        size={size}
+        onPageChange={setPage}
+      />
+    </div>
   )
 }

--- a/src/styles/modal.ts
+++ b/src/styles/modal.ts
@@ -2,7 +2,7 @@ import { cva } from 'class-variance-authority'
 
 export const modalPanel = cva(
   // 공통 스타일
-  'absolute left-1/2 top-1/2 w-[min(92vw,900px)] -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white shadow-2xl',
+  'absolute left-1/2 top-1/2 flex flex-col w-[min(92vw,900px)] max-h-[80vh] overflow-hidden -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white shadow-2xl',
   {
     variants: {
       size: {

--- a/src/types/badwords-ko.d.ts
+++ b/src/types/badwords-ko.d.ts
@@ -1,0 +1,11 @@
+// 이 파일은 'badwords-ko' 라이브러리에 대한 TypeScript 타입 선언입니다
+// 해당 패키지는 타입 정의가 제공되지 않아서 직접 작성했습니다.
+declare module 'badwords-ko' {
+  export default class Filter {
+    constructor()
+    addWords(...words: string[]): void //사용자 정의 금칙어 추가
+    removeWords(...words: string[]): void //특정 금칙어 제거
+    clean(text: string): string //입력된 문자열에서 욕설을 치환
+    isProfane(text: string): boolean //입력된 문자열에 욕설이 포함되어 있는지 검사
+  }
+}

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,0 +1,4 @@
+export interface Tag {
+  id: number
+  name: string
+}

--- a/src/validations/tag.ts
+++ b/src/validations/tag.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+import Filter from 'badwords-ko'
+
+const filter = new Filter() // 한국어 비속어 필터
+
+const ALLOWED = /^[가-힣a-zA-Z0-9_-]+$/ // 공백 X, _, - 허용
+
+export const tagSchema = z
+  .string()
+  .trim()
+  .min(2, '태그는 2자 이상이어야 합니다.')
+  .max(20, '태그는 20자 이하여야 합니다.')
+  .regex(ALLOWED, '한글/영문/숫자 및 특수문자는 _ - 만 사용할 수 있습니다.')
+
+export const checkTagValidity = (raw: string) => {
+  const result = tagSchema.safeParse(raw)
+  if (!result.success)
+    return result.error.issues[0]?.message ?? '입력이 올바르지 않습니다.'
+  if (filter.isProfane(result.data)) return '부적절한 단어가 포함되어 있습니다.'
+  return null // 통과
+}


### PR DESCRIPTION
## 📌 개요

- 태그 검색 모달 및 관련 컴포넌트/훅 구현
- 태그 등록, 검색, 선택 기능 추가

## 🔧 작업 내용

- [x] TagSearchModal 컴포넌트 구현 및 UI 분리 (SelectedTagSection, TagResultSection, TagCreateBox)
- [x] 훅 분리: useTagManager, useSelectedTags
- [x] 태그 API 연동 및 MSW 핸들러 추가
- [x] badwords-ko 라이브러리 기반 검증 추가

## 📎 관련 이슈

closes #159 

![태그모달영상](https://github.com/user-attachments/assets/5d42c63e-7f56-4535-bbe3-9f3bcddfa161)

## 💬 리뷰어 참고 사항

- MSW 핸들러 구조와 실제 API 교체 시 영향도 체크 부탁드려요 (제가 확인했을 땐 문제 없음)
- 작업하다 보니 눈엣가시처럼 거슬리던 부분들이 많아, 한 브랜치에서 수정 사항을 한 번에 처리했습니다.
