### PR TITLE
refactor: 공고 상세 페이지 컴포넌트 수정

### DIFF
--- a/src/components/commons/MarkdownComponents.tsx
+++ b/src/components/commons/MarkdownComponents.tsx
@@ -1,0 +1,37 @@
+import { markdownStyles } from '@src/styles/markdownStyles'
+
+const styles = markdownStyles
+
+export const MarkdownComponents = {
+  h1: ({ ...props }) => <h1 className={styles.h1} {...props} />,
+  h2: ({ ...props }) => <h2 className={styles.h2} {...props} />,
+  h3: ({ ...props }) => <h3 className={styles.h3} {...props} />,
+  h4: ({ ...props }) => <h4 className={styles.h4} {...props} />,
+  h5: ({ ...props }) => <h5 className={styles.h5} {...props} />,
+  h6: ({ ...props }) => <h6 className={styles.h6} {...props} />,
+  p: ({ ...props }) => <p className={styles.p} {...props} />,
+  ul: ({ ...props }) => <ul className={styles.ul} {...props} />,
+  ol: ({ ...props }) => <ol className={styles.ol} {...props} />,
+  li: ({ ...props }) => <li className={styles.li} {...props} />,
+  img: ({ ...props }) => <img className={styles.img} {...props} />,
+  blockquote: ({ ...props }) => (
+    <blockquote className={styles.blockquote} {...props} />
+  ),
+  code: (props: React.HTMLAttributes<HTMLElement>) => {
+    const isInline = !props.className?.includes('language-')
+    return isInline ? (
+      <code className={styles.code} {...props} />
+    ) : (
+      <code {...props} />
+    )
+  },
+  pre: ({ ...props }) => <pre className={styles.pre} {...props} />,
+  a: ({ ...props }) => <a className={styles.a} {...props} />,
+  strong: ({ ...props }) => <strong className={styles.strong} {...props} />,
+  em: ({ ...props }) => <em className={styles.em} {...props} />,
+  hr: ({ ...props }) => <hr className={styles.hr} {...props} />,
+  table: ({ ...props }) => <table className={styles.table} {...props} />,
+  th: ({ ...props }) => <th className={styles.th} {...props} />,
+  td: ({ ...props }) => <td className={styles.td} {...props} />,
+  tr: ({ ...props }) => <tr className={styles.tr} {...props} />,
+}

--- a/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
+++ b/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
@@ -1,6 +1,5 @@
 import RecEditPriceInput from '../recruitment-edit/RecEditPriceInput'
 import { FileUploadBox } from './FileUploadBox'
-import PriceInput from './PriceInput'
 import TagSection from './tag-ui/TagSection'
 
 interface PresetFile {

--- a/src/components/recruitment-detail/recruitment-attachment-list/RecruitmentAttachmentList.tsx
+++ b/src/components/recruitment-detail/recruitment-attachment-list/RecruitmentAttachmentList.tsx
@@ -7,7 +7,10 @@ export default function RecruitmentAttachmentList() {
       <h3 className="mb-4 pb-6 text-2xl font-bold">첨부 파일</h3>
       <div className="flex flex-col gap-4">
         {post.attachments.map((file, index) => (
-          <RecruitmentAttachmentFile key={index} file={file} />
+          <RecruitmentAttachmentFile
+            key={`${file.file_url}-${index}`}
+            file={file}
+          />
         ))}
       </div>
     </div>

--- a/src/components/recruitment-detail/recruitment-banner/BannerInfoBoxs.tsx
+++ b/src/components/recruitment-detail/recruitment-banner/BannerInfoBoxs.tsx
@@ -19,6 +19,9 @@ export function BannerInfoBoxs({ post }: BannerInfoBoxsProps) {
     day: '2-digit',
   }).format(date)
 
+  const cost = post.cost
+  const postCost = cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+
   const iconClass = 'h-6 w-6 text-gray-700'
   const stats = [
     {
@@ -29,7 +32,7 @@ export function BannerInfoBoxs({ post }: BannerInfoBoxsProps) {
     {
       icon: <CoinsIcon className={iconClass} />,
       label: '예상 비용',
-      value: `${post.cost}원`,
+      value: `${postCost}원`,
     },
     {
       icon: <CalendarIcon className={iconClass} />,

--- a/src/components/recruitment-detail/recruitment-banner/BannerInfoBoxs.tsx
+++ b/src/components/recruitment-detail/recruitment-banner/BannerInfoBoxs.tsx
@@ -45,9 +45,9 @@ export function BannerInfoBoxs({ post }: BannerInfoBoxsProps) {
 
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-      {stats.map((stat, idx) => (
+      {stats.map((stat, index) => (
         <div
-          key={idx}
+          key={`${stat.value}-${index}`}
           className="flex flex-col items-center rounded-lg bg-gray-50 p-4 transition"
         >
           {stat.icon}

--- a/src/components/recruitment-detail/recruitment-banner/BannerInfoList.tsx
+++ b/src/components/recruitment-detail/recruitment-banner/BannerInfoList.tsx
@@ -15,9 +15,9 @@ interface BannerInfoListProps {
 export function BannerInfoList({ items }: BannerInfoListProps) {
   return (
     <div className="flex flex-wrap space-x-6">
-      {items.map((item) => (
+      {items.map((item, index) => (
         <div
-          key={item.label}
+          key={`${item.value}-${index}`}
           className="flex items-center gap-2 text-sm text-gray-600"
         >
           <Icon icon={item.icon} size={16} />

--- a/src/components/recruitment-detail/recruitment-banner/BannerTags.tsx
+++ b/src/components/recruitment-detail/recruitment-banner/BannerTags.tsx
@@ -8,9 +8,9 @@ interface BannerTagsProps {
 export function BannerTags({ tags }: BannerTagsProps) {
   return (
     <div className="flex gap-2">
-      {tags.map((tag) => (
+      {tags.map((tag, index) => (
         <Badge
-          key={tag.name}
+          key={`${tag.name}-${index}`}
           badgeTitle={tag.name}
           className="bg-primary-100 text-primary-800"
         />

--- a/src/components/recruitment-detail/recruitment-content/RecruitmentContent.tsx
+++ b/src/components/recruitment-detail/recruitment-content/RecruitmentContent.tsx
@@ -1,52 +1,12 @@
+import { MarkdownComponents } from '@src/components/commons/MarkdownComponents'
 import { post } from '@src/mock/post'
-import { markdownStyles } from '@src/styles/markdownStyles'
 import ReactMarkdown from 'react-markdown'
-
-const styles = markdownStyles
 
 export default function RecruitmentContent() {
   return (
     <div className="w-full rounded-xl border border-gray-200 bg-white p-8 pb-18">
       <h3 className="mb-4 pb-6 text-2xl font-bold">공고 내용</h3>
-      <ReactMarkdown
-        components={{
-          h1: ({ ...props }) => <h1 className={styles.h1} {...props} />,
-          h2: ({ ...props }) => <h2 className={styles.h2} {...props} />,
-          h3: ({ ...props }) => <h3 className={styles.h3} {...props} />,
-          h4: ({ ...props }) => <h4 className={styles.h4} {...props} />,
-          h5: ({ ...props }) => <h5 className={styles.h5} {...props} />,
-          h6: ({ ...props }) => <h6 className={styles.h6} {...props} />,
-          p: ({ ...props }) => <p className={styles.p} {...props} />,
-          ul: ({ ...props }) => <ul className={styles.ul} {...props} />,
-          ol: ({ ...props }) => <ol className={styles.ol} {...props} />,
-          li: ({ ...props }) => <li className={styles.li} {...props} />,
-          img: ({ ...props }) => <img className={styles.img} {...props} />,
-          blockquote: ({ ...props }) => (
-            <blockquote className={styles.blockquote} {...props} />
-          ),
-          code: (props) => {
-            const isInline = !props.className?.includes('language-')
-            return isInline ? (
-              <code className={styles.code} {...props} />
-            ) : (
-              <code {...props} />
-            )
-          },
-          pre: ({ ...props }) => <pre className={styles.pre} {...props} />,
-          a: ({ ...props }) => <a className={styles.a} {...props} />,
-          strong: ({ ...props }) => (
-            <strong className={styles.strong} {...props} />
-          ),
-          em: ({ ...props }) => <em className={styles.em} {...props} />,
-          hr: ({ ...props }) => <hr className={styles.hr} {...props} />,
-          table: ({ ...props }) => (
-            <table className={styles.table} {...props} />
-          ),
-          th: ({ ...props }) => <th className={styles.th} {...props} />,
-          td: ({ ...props }) => <td className={styles.td} {...props} />,
-          tr: ({ ...props }) => <tr className={styles.tr} {...props} />,
-        }}
-      >
+      <ReactMarkdown components={MarkdownComponents}>
         {post.content}
       </ReactMarkdown>
     </div>

--- a/src/components/recruitment-detail/recuitment-lecture/RecuitmentLecture.tsx
+++ b/src/components/recruitment-detail/recuitment-lecture/RecuitmentLecture.tsx
@@ -6,8 +6,8 @@ export default function RecuitmentLecture() {
     <div className="w-full rounded-xl border border-gray-200 bg-white p-8">
       <h3 className="mb-4 pb-6 text-2xl font-bold">스터디 강의 목록</h3>
       <div className="grid grid-cols-2 gap-6">
-        {post.lectures.map((lecture, index) => (
-          <LectureCard key={index} lecture={lecture} />
+        {post.lectures.map((lecture) => (
+          <LectureCard key={lecture.url} lecture={lecture} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## 📌 개요
공고 상세 페이지 컴포넌트 수정 했습니다.

## 🔧 작업 내용
- key 고유한 값으로 수정
- 마크다운 스타일 지정 commons에 공통 컴포넌트화

## 추가 작업
- 비용에 쉼표 추가
<img width="138" height="79" alt="image" src="https://github.com/user-attachments/assets/b2b5d49a-c37b-4ee5-a5ae-684794d63eca" />

## 📎 관련 이슈
closes #192 
