### PR TITLE
refactor: 커스텀 마크다운 리팩토링

### DIFF
--- a/src/components/recruitment-create/RecCreateContentSection.tsx
+++ b/src/components/recruitment-create/RecCreateContentSection.tsx
@@ -1,11 +1,15 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import StudyIntroMarkdown from './StudyIntroMarkdown'
 import { STUDY_INTRO_PLACEHOLDER } from '@src/constants/studyintroplaceholder'
+import { countMdImages } from './markdown-ui/mdImages'
+
+const MAX_IMAGES = 5
 
 const PLACEHOLDER = STUDY_INTRO_PLACEHOLDER
 
 export default function RecCreateContentSection() {
   const [markDown, setMarkDown] = useState('')
+  const usedCount = useMemo(() => countMdImages(markDown), [markDown])
 
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
@@ -19,7 +23,9 @@ export default function RecCreateContentSection() {
       </label>
       <div className="flex justify-between text-[12px] font-normal text-gray-500">
         <p>마크다운 문법을 사용할 수 있습니다</p>
-        <p>이미지 0/5개</p>
+        <p>
+          이미지 {usedCount}/{MAX_IMAGES}개
+        </p>
       </div>
       <label className="mt-2 mb-2 block text-sm leading-5 font-medium text-gray-700">
         스터디 그룹 소개(선택사항)

--- a/src/components/recruitment-create/StudyIntroMarkdown.tsx
+++ b/src/components/recruitment-create/StudyIntroMarkdown.tsx
@@ -6,6 +6,7 @@ import { useMdCommands } from './markdown-ui/useMdCommands'
 import { useImageUploader } from './markdown-ui/useImageUploader'
 import { useMdImageDnDPaste } from './markdown-ui/useMdImageDnDPaste'
 import { countMdImages } from './markdown-ui/mdImages'
+import { useToast } from '@components/commons/toast'
 
 interface StudyIntroProps {
   value: string
@@ -13,7 +14,7 @@ interface StudyIntroProps {
   placeholder?: string
   height?: number
 }
-
+const MAX_IMAGES = 5
 const PLACEHOLDER =
   '# 스터디 소개\nReact 실무 프로젝트를 함께 진행할 팀원을 모집합니다!\n\n## 스터디 내용\n- React 기초부터 실무 적용까지\n- 실제 프로젝트 개발 경험\n- 코드 리뷰 및 피드백'
 
@@ -35,29 +36,109 @@ export default function StudyIntroMarkdown({
     insertImage,
   } = useMdCommands(onChange)
 
+  const toast = useToast()
+
   const { upload, isUploading } = useImageUploader({
     mode: 'mock',
     maxSize: 10 * 1024 * 1024,
-    onError: (m) => alert(m),
+    onError: (m) =>
+      toast.error({
+        title: '업로드 실패',
+        content: m || '이미지 업로드 중 오류가 발생했습니다.',
+      }),
   })
 
   const handleFileUpload = useCallback(
     async (file: File) => {
-      if (!file.type.startsWith('image/')) return
+      if (!file.type.startsWith('image/')) {
+        toast.error({
+          title: '이미지 파일만 업로드',
+          content: 'PNG, JPG, GIF, WEBP 등을 지원해요.',
+        })
+        return
+      }
+
+      const left = MAX_IMAGES - countMdImages(value, true)
+      if (left <= 0) {
+        toast.warning({
+          title: '이미지 업로드 제한',
+          content: `이미지는 최대 ${MAX_IMAGES}장까지 업로드할 수 있어요.`,
+        })
+        return
+      }
+
       const { url } = await upload(file)
       const alt = file.name.replace(/\.(png|jpe?g|gif|webp|svg|bmp|heic)$/i, '')
       insertImage(url, alt)
     },
-    [upload, insertImage]
+    [upload, insertImage, value, toast]
   )
 
   const { onDrop, onDragOver, onPaste } = useMdImageDnDPaste(handleFileUpload, {
-    max: 5,
-    getCount: () => countMdImages(value),
-    onLimit: (left) => {
-      if (left <= 0) alert('이미지는 최대 5장까지 가능합니다.')
-    },
+    max: MAX_IMAGES,
+    getCount: () => countMdImages(value, true),
+    onLimit: (left) =>
+      toast.warning({
+        title: '이미지 업로드 제한',
+        content:
+          left <= 0
+            ? `이미지는 최대 ${MAX_IMAGES}장까지 업로드할 수 있어요.`
+            : `남은 업로드 가능 수: ${left}장`,
+      }),
   })
+
+  const isImageByName = (name?: string) =>
+    !!name && /\.(png|jpe?g|gif|webp|bmp|svg|heic)$/i.test(name)
+
+  const onDropWithToast = useCallback(
+    (e: React.DragEvent<HTMLTextAreaElement>) => {
+      const dt = e.dataTransfer
+      if (dt) {
+        const files = dt.files?.length
+          ? Array.from(dt.files)
+          : dt.items
+            ? Array.from(dt.items)
+                .map((it) => (it.kind === 'file' ? it.getAsFile() : null))
+                .filter((f): f is File => !!f)
+            : []
+
+        const hasNonImage = files.some(
+          (f) => !(f.type?.startsWith('image/') || isImageByName(f.name))
+        )
+        if (hasNonImage) {
+          toast.error({
+            title: '이미지 파일만 업로드',
+            content: 'PNG, JPG, GIF, WEBP 등을 지원해요.',
+          })
+        }
+      }
+      onDrop(e)
+    },
+    [onDrop, toast]
+  )
+
+  const onPasteWithToast = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items
+      if (items?.length) {
+        const fileItems = Array.from(items).filter((i) => i.kind === 'file')
+        if (fileItems.length) {
+          const hasNonImage = fileItems.some(
+            (i) => !i.type.startsWith('image/')
+          )
+          if (hasNonImage) {
+            toast.error({
+              title: '이미지 파일만 업로드',
+              content: 'PNG, JPG, GIF, WEBP 등을 지원해요.',
+            })
+            // 텍스트 붙여넣기는 방해하지 않으므로 여기선 preventDefault 안 함
+          }
+        }
+      }
+      onPaste(e)
+    },
+    [onPaste, toast]
+  )
 
   const views = {
     edit: (
@@ -67,9 +148,9 @@ export default function StudyIntroMarkdown({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         style={{ height }}
-        onDrop={onDrop}
+        onDrop={onDropWithToast}
         onDragOver={onDragOver}
-        onPaste={onPaste}
+        onPaste={onPasteWithToast}
         className="block w-full resize-none border-t border-gray-200 bg-white p-3 text-sm outline-none"
       />
     ),

--- a/src/components/recruitment-create/StudyIntroMarkdown.tsx
+++ b/src/components/recruitment-create/StudyIntroMarkdown.tsx
@@ -1,8 +1,11 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import MdToolbar from './markdown-ui/MdToolbar'
 import MdPreview from './markdown-ui/MdPreview'
 import MdFooter from './markdown-ui/MdFooter'
 import { useMdCommands } from './markdown-ui/useMdCommands'
+import { useImageUploader } from './markdown-ui/useImageUploader'
+import { useMdImageDnDPaste } from './markdown-ui/useMdImageDnDPaste'
+import { countMdImages } from './markdown-ui/mdImages'
 
 interface StudyIntroProps {
   value: string
@@ -11,19 +14,51 @@ interface StudyIntroProps {
   height?: number
 }
 
+const PLACEHOLDER =
+  '# 스터디 소개\nReact 실무 프로젝트를 함께 진행할 팀원을 모집합니다!\n\n## 스터디 내용\n- React 기초부터 실무 적용까지\n- 실제 프로젝트 개발 경험\n- 코드 리뷰 및 피드백'
+
 export default function StudyIntroMarkdown({
   value,
   onChange,
-  placeholder = '# 스터디 소개\nReact 실무 프로젝트를 함께 진행할 팀원을 모집합니다!\n\n## 스터디 내용\n- React 기초부터 실무 적용까지\n- 실제 프로젝트 개발 경험\n- 코드 리뷰 및 피드백',
+  placeholder = PLACEHOLDER,
   height = 282,
 }: StudyIntroProps) {
   const [tab, setTab] = useState<'edit' | 'preview'>('edit')
 
-  // 최상단 버튼 Hooks: textarea를 직접 조작하는 커맨드 훅 (굵게/기울임/H1/리스트/링크)
-  const { taRef, wrapInline, insertLink, toggleH1, toggleUl, toggleOl } =
-    useMdCommands(onChange)
+  const {
+    taRef,
+    wrapInline,
+    insertLink,
+    toggleH1,
+    toggleUl,
+    toggleOl,
+    insertImage,
+  } = useMdCommands(onChange)
 
-  // 메인 view 부분 분기처리
+  const { upload, isUploading } = useImageUploader({
+    mode: 'mock',
+    maxSize: 10 * 1024 * 1024,
+    onError: (m) => alert(m),
+  })
+
+  const handleFileUpload = useCallback(
+    async (file: File) => {
+      if (!file.type.startsWith('image/')) return
+      const { url } = await upload(file)
+      const alt = file.name.replace(/\.(png|jpe?g|gif|webp|svg|bmp|heic)$/i, '')
+      insertImage(url, alt)
+    },
+    [upload, insertImage]
+  )
+
+  const { onDrop, onDragOver, onPaste } = useMdImageDnDPaste(handleFileUpload, {
+    max: 5,
+    getCount: () => countMdImages(value),
+    onLimit: (left) => {
+      if (left <= 0) alert('이미지는 최대 5장까지 가능합니다.')
+    },
+  })
+
   const views = {
     edit: (
       <textarea
@@ -32,6 +67,9 @@ export default function StudyIntroMarkdown({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         style={{ height }}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onPaste={onPaste}
         className="block w-full resize-none border-t border-gray-200 bg-white p-3 text-sm outline-none"
       />
     ),
@@ -52,11 +90,21 @@ export default function StudyIntroMarkdown({
           onBullet={toggleUl}
           onNumber={toggleOl}
         />
-        {/* 본문  */}
         {views[tab]}
 
-        {/* 풋터(하단의 텍스트 가이드) */}
-        <MdFooter />
+        <MdFooter>
+          <div className="flex flex-wrap items-center gap-2">
+            <span>마크다운 문법을 사용할 수 있습니다.</span>
+            <strong>**굵게**</strong>
+            <em>*기울임*</em>
+            <span>`코드`</span>
+            <span>[링크](URL)</span>
+            <span>## 제목</span>
+            <span className="ml-auto">
+              {isUploading ? '이미지 업로드 중…' : ''}
+            </span>
+          </div>
+        </MdFooter>
       </div>
     </div>
   )

--- a/src/components/recruitment-create/markdown-ui/mdImages.ts
+++ b/src/components/recruitment-create/markdown-ui/mdImages.ts
@@ -1,0 +1,16 @@
+const IMG_DONE_RE = /!\[[^\]]*]\((?:https?:|data:|blob:)[^)]+\)/g
+
+const IMG_UPLOADING_RE = /!\[Uploading [^\]]*]\(\)/g
+
+export function countMdImages(md: string, includeUploading = false): number {
+  const done = (md.match(IMG_DONE_RE) ?? []).length
+  if (!includeUploading) return done
+  const uploading = (md.match(IMG_UPLOADING_RE) ?? []).length
+  return done + uploading
+}
+
+export function takeUntilMax<T>(arr: T[] | ArrayLike<T>, max: number): T[] {
+  if (!max || max <= 0) return []
+  const a = Array.from(arr as ArrayLike<T>)
+  return a.slice(0, max)
+}

--- a/src/components/recruitment-create/markdown-ui/sanitizeSchema.ts
+++ b/src/components/recruitment-create/markdown-ui/sanitizeSchema.ts
@@ -40,6 +40,6 @@ export const mdSanitizeSchema = {
   },
   protocols: {
     ...(defaultSchema.protocols || {}),
-    img: { src: ['http', 'https', 'data'] },
+    img: { src: ['http', 'https', 'data', 'blob'] },
   },
 } as const

--- a/src/components/recruitment-create/markdown-ui/useImageUploader.ts
+++ b/src/components/recruitment-create/markdown-ui/useImageUploader.ts
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+
+export interface UploadResult {
+  url: string
+  width?: number
+  height?: number
+}
+
+export interface Uploader {
+  upload(file: File): Promise<UploadResult>
+}
+
+function createMockUploader(): Uploader {
+  return {
+    async upload(file: File) {
+      if (!file.type.startsWith('image/')) {
+        throw new Error('이미지 파일만 업로드 할 수 있습니다.')
+      }
+
+      const url = URL.createObjectURL(file)
+
+      const displayImgs = await new Promise<{ w?: number; h?: number }>(
+        (res) => {
+          const img = new Image()
+          img.onload = () => res({ w: img.width, h: img.height })
+          img.onerror = () => res({})
+          img.src = url
+        }
+      )
+
+      return { url, width: displayImgs.w, height: displayImgs.h }
+    },
+  }
+}
+
+function createS3Uploader(baseUrl = '/api/uploads'): Uploader {
+  return {
+    async upload(file: File) {
+      const presignRes = await fetch(
+        `${baseUrl}/presign?filename=${encodeURIComponent(file.name)}&type=${encodeURIComponent(file.type)}`
+      )
+      if (!presignRes.ok) throw new Error('업로드 URL을 받는 데 실패했습니다.')
+      const { url, fields, putUrl, getUrl } = await presignRes.json()
+      if (url && fields) {
+        const form = new FormData()
+        Object.entries(fields).forEach(([k, v]) => form.append(k, v as string))
+        form.append('file', file)
+        const uploadRes = await fetch(url, { method: 'POST', body: form })
+        if (!uploadRes.ok) throw new Error('S3 업로드 실패')
+        return { url: getUrl ?? `${url}/${fields.key}` }
+      }
+      if (putUrl) {
+        const uploadRes = await fetch(putUrl, {
+          method: 'PUT',
+          body: file,
+          headers: { 'Content-Type': file.type },
+        })
+        if (!uploadRes.ok) throw new Error('S3 업로드 실패')
+        return { url: getUrl ?? putUrl.split('?')[0] }
+      }
+      throw new Error('서버 응답 형식이 올바르지 않습니다.')
+    },
+  }
+}
+
+export function useImageUploader(opts?: {
+  mode?: 'mock' | 's3'
+  s3BaseUrl?: string
+  maxSize?: number
+  onError?: (msg: string) => void
+}) {
+  const [isUploading, setUploading] = useState(false)
+  const {
+    mode = 'mock',
+    s3BaseUrl,
+    maxSize = 5 * 1024 * 1024,
+    onError,
+  } = opts || {}
+  const impl: Uploader =
+    mode === 's3' ? createS3Uploader(s3BaseUrl) : createMockUploader()
+
+  const upload: (file: File) => Promise<UploadResult> = async (file) => {
+    try {
+      if (file.size > maxSize)
+        throw new Error('파일 크기가 허용 용량을 초과했습니다.')
+      setUploading(true)
+      const res = await impl.upload(file)
+      return res
+    } catch (e: unknown) {
+      const msg =
+        e instanceof Error ? e.message : '이미지 업로드 중 오류가 발생했습니다.'
+      onError?.(msg)
+      throw e
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return { upload, isUploading }
+}

--- a/src/components/recruitment-create/markdown-ui/useMdCommands.ts
+++ b/src/components/recruitment-create/markdown-ui/useMdCommands.ts
@@ -83,5 +83,20 @@ export function useMdCommands(onChange: (v: string) => void) {
   const toggleUl = () => toggleLinePrefix('- ', /^-\s+/)
   const toggleOl = () => toggleLinePrefix('1. ', /^\d+\.\s+/)
 
-  return { taRef, wrapInline, insertLink, toggleH1, toggleUl, toggleOl }
+  const insertImage = (url: string, alt = 'image') =>
+    withTA((ta) => {
+      const { selectionStart: s, selectionEnd: e } = ta
+      const md = `![${alt}](${url})`
+      ta.setRangeText(md, s, e, 'end')
+    })
+
+  return {
+    taRef,
+    wrapInline,
+    insertLink,
+    toggleH1,
+    toggleUl,
+    toggleOl,
+    insertImage,
+  }
 }

--- a/src/components/recruitment-create/markdown-ui/useMdImageDnDPaste.ts
+++ b/src/components/recruitment-create/markdown-ui/useMdImageDnDPaste.ts
@@ -1,0 +1,129 @@
+import { useCallback } from 'react'
+import { takeUntilMax } from './mdImages'
+
+interface Opts {
+  max?: number
+  getCount?: () => number
+  onLimit?: (left: number) => void
+}
+
+export function useMdImageDnDPaste(
+  onFile: (file: File) => Promise<void>,
+  opts: Opts = {}
+) {
+  const { max = Number.POSITIVE_INFINITY, getCount, onLimit } = opts
+
+  const getLeft = useCallback(() => {
+    const cur = getCount?.() ?? 0
+    return Math.max(0, max - cur)
+  }, [getCount, max])
+
+  const looksImage = (f: File) =>
+    f.type?.startsWith('image/') ||
+    /\.(png|jpe?g|gif|webp|bmp|svg|heic)$/i.test(f.name || '')
+
+  const handleFiles = useCallback(
+    async (files: File[] | FileList) => {
+      const left = getLeft()
+      if (left <= 0) {
+        onLimit?.(0)
+        return
+      }
+
+      const all = Array.from(files).filter(looksImage)
+      if (all.length === 0) return
+
+      const picked = takeUntilMax(all, left)
+      const skipped = all.length - picked.length
+
+      for (const f of picked) {
+        await onFile(f)
+      }
+
+      if (skipped > 0 || picked.length === 0) {
+        onLimit?.(Math.max(0, left - picked.length))
+      }
+    },
+    [getLeft, onFile, onLimit]
+  )
+
+  const handleUrlFallback = useCallback(
+    async (e: React.DragEvent<HTMLTextAreaElement>) => {
+      const left = getLeft()
+      if (left <= 0) {
+        onLimit?.(0)
+        return false
+      }
+      const dt = e.dataTransfer
+      const uri = dt.getData('text/uri-list') || dt.getData('text/plain') || ''
+      if (!/^https?:\/\//i.test(uri)) return false
+      try {
+        const resp = await fetch(uri, { mode: 'cors' })
+        const blob = await resp.blob()
+        const file = new File([blob], `dropped-${Date.now()}.png`, {
+          type: blob.type || 'image/*',
+        })
+        await onFile(file)
+        return true
+      } catch {
+        return false
+      }
+    },
+    [getLeft, onFile, onLimit]
+  )
+
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLTextAreaElement>) => {
+      e.preventDefault()
+      const dt = e.dataTransfer
+      if (!dt) return
+
+      if (dt.files?.length) {
+        void handleFiles(dt.files)
+        return
+      }
+
+      if (dt.items?.length) {
+        const files: File[] = []
+        for (const it of Array.from(dt.items)) {
+          if (it.kind === 'file') {
+            const f = it.getAsFile()
+            if (f) files.push(f)
+          }
+        }
+        if (files.length) {
+          void handleFiles(files)
+          return
+        }
+      }
+
+      void handleUrlFallback(e)
+    },
+    [handleFiles, handleUrlFallback]
+  )
+
+  const onDragOver = useCallback((e: React.DragEvent<HTMLTextAreaElement>) => {
+    e.preventDefault()
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+  }, [])
+
+  const onPaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items
+      if (!items?.length) return
+
+      const files = Array.from(items)
+        .filter((i) => i.type.startsWith('image/'))
+        .map((i) => i.getAsFile())
+        .filter((f): f is File => !!f)
+
+      if (!files.length) return
+
+      e.preventDefault()
+      void handleFiles(files)
+    },
+    [handleFiles]
+  )
+
+  return { onDrop, onDragOver, onPaste }
+}

--- a/src/components/recruitment-create/markdown-ui/useMdImageUpload.ts
+++ b/src/components/recruitment-create/markdown-ui/useMdImageUpload.ts
@@ -1,0 +1,65 @@
+import { useCallback } from 'react'
+import { useImageUploader } from './useImageUploader'
+import { useMdImageDnDPaste } from './useMdImageDnDPaste'
+import { useMdCommands } from './useMdCommands'
+
+type Mode = 'mock' | 's3'
+
+interface Options {
+  onChange: (v: string) => void
+  mode?: Mode
+  s3BaseUrl?: string
+  maxSize?: number
+  onError?: (msg: string) => void
+}
+
+export function useMarkdownImageUpload({
+  onChange,
+  mode = 'mock',
+  s3BaseUrl,
+  maxSize = 10 * 1024 * 1024,
+  onError,
+}: Options) {
+  const {
+    taRef,
+    wrapInline,
+    insertLink,
+    toggleH1,
+    toggleUl,
+    toggleOl,
+    insertImage,
+  } = useMdCommands(onChange)
+
+  const { upload, isUploading } = useImageUploader({
+    mode,
+    s3BaseUrl,
+    maxSize,
+    onError,
+  })
+
+  // 파일 → 업로드 → 마크다운 이미지 삽입
+  const handleFileUpload = useCallback(
+    async (file: File) => {
+      if (!file.type.startsWith('image/')) return
+      const { url } = await upload(file) // Promise<UploadResult>
+      const alt = file.name.replace(/\.(png|jpe?g|gif|webp|svg|bmp|heic)$/i, '')
+      insertImage(url, alt)
+    },
+    [upload, insertImage]
+  )
+
+  const { onDrop, onDragOver, onPaste } = useMdImageDnDPaste(handleFileUpload)
+
+  return {
+    taRef,
+    onDrop,
+    onDragOver,
+    onPaste,
+    wrapInline,
+    insertLink,
+    toggleH1,
+    toggleUl,
+    toggleOl,
+    isUploading,
+  }
+}

--- a/src/components/recruitment-edit/RecEditContentSection.tsx
+++ b/src/components/recruitment-edit/RecEditContentSection.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import StudyIntroMarkdown from '../recruitment-create/StudyIntroMarkdown'
 import { STUDY_INTRO_PLACEHOLDER } from '@src/constants/studyintroplaceholder'
+import { countMdImages } from '../recruitment-create/markdown-ui/mdImages'
 
 interface RecEditContentSectionProps {
   defaultMarkDown?: string
@@ -8,6 +9,7 @@ interface RecEditContentSectionProps {
 }
 
 const PLACEHOLDER = STUDY_INTRO_PLACEHOLDER
+const MAX_IMAGES = 5
 
 export default function RecEditContentSection({
   defaultMarkDown,
@@ -19,6 +21,11 @@ export default function RecEditContentSection({
     if (defaultMarkDown !== undefined) setMarkDown(defaultMarkDown)
   }, [defaultMarkDown])
 
+  const usedCount = useMemo(
+    () => countMdImages(markDown, true), // 업로드중 자리표시자까지 포함하려면 true
+    [markDown]
+  )
+
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
       <p className="text-[20px] leading-7 font-semibold">공고 내용</p>
@@ -29,13 +36,18 @@ export default function RecEditContentSection({
           *
         </span>
       </label>
+
       <div className="flex justify-between text-[12px] font-normal text-gray-500">
         <p>마크다운 문법을 사용할 수 있습니다</p>
-        <p>이미지 0/5개</p>
+        <p>
+          이미지 {usedCount}/{MAX_IMAGES}개
+        </p>
       </div>
+
       <label className="mt-2 mb-2 block text-sm leading-5 font-medium text-gray-700">
         스터디 그룹 소개(선택사항)
       </label>
+
       <StudyIntroMarkdown
         value={markDown}
         onChange={(value) => {
@@ -45,9 +57,12 @@ export default function RecEditContentSection({
         placeholder={PLACEHOLDER}
         height={320}
       />
+
       <div className="pt-2 text-[12px] leading-4 font-normal text-gray-500">
         <p>• 마크다운 문법: **굵게**, *기울임*, # 제목, - 목록 등</p>
-        <p>• 이미지 추가: ![설명](이미지URL) - 최대 5개, 각 5MB 이하</p>
+        <p>
+          • 이미지 추가: ![설명](이미지URL) - 최대 {MAX_IMAGES}개, 각 5MB 이하
+        </p>
       </div>
     </div>
   )

--- a/src/constants/recmdtoastmessage.ts
+++ b/src/constants/recmdtoastmessage.ts
@@ -1,0 +1,16 @@
+export const TOAST_MESSAGES = {
+  IMAGE: {
+    LIMIT: (max: number) => ({
+      title: '이미지 업로드 제한',
+      content: `이미지는 최대 ${max}장까지 업로드할 수 있어요.`,
+    }),
+    NOT_IMAGE: {
+      title: '이미지 파일만 업로드',
+      content: 'PNG, JPG, GIF, WEBP 등을 지원해요.',
+    },
+    UPLOAD_FAIL: (msg?: string) => ({
+      title: '업로드 실패',
+      content: msg || '이미지 업로드 중 오류가 발생했습니다.',
+    }),
+  },
+} as const


### PR DESCRIPTION
## 📌 개요

현재는 이미지를 받아올 수 있는 방식을 하단에 있는 스터디 그룹 대표 이미지라고 생각을 하여 이미지를 삽입하는 것을 `![설명](이미지URL)` 와 같은 방식으로 구사를 해놓은 상태이며, 최대 5개까지만 들어갈 수 있기에 이를 막을 수 있는 작업 또한 진행을 완료하여 이를 PR 요청

## 🔧 작업 내용

- [ ] 마크다운에 이미지가 업로드가 되도록 세팅
- [ ] 올라간 이미지의 갯수가 나오도록 세팅
- [ ] alert 메시지 대신에 토스트 알람으로 에러를 표기.

## 📎 관련 이슈

closes #166 

## 💬 리뷰어 참고 사항

- 마크다운에 이미지가 올라가도록 세팅 작업을 진행했습니다.
