### PR TITLE
refactor: 헬퍼 함수로 중복코드 제거 및 cn사용

### DIFF
--- a/src/components/commons/MarkdownComponents.tsx
+++ b/src/components/commons/MarkdownComponents.tsx
@@ -1,37 +1,66 @@
+import React from 'react'
 import { markdownStyles } from '@src/styles/markdownStyles'
+import { cn } from '@src/utils/cn'
 
 const styles = markdownStyles
 
+// 헬퍼 함수
+function createComponent<T extends keyof React.JSX.IntrinsicElements>(
+  tag: T,
+  styleClass: string
+) {
+  function Component(props: React.JSX.IntrinsicElements[T]) {
+    const { className, ...rest } = props
+    return React.createElement(tag, {
+      ...rest,
+      className: cn(styleClass, className as string),
+    })
+  }
+
+  Component.displayName = `Markdown${tag.toString().charAt(0).toUpperCase() + tag.toString().slice(1)}`
+  return Component
+}
+
 export const MarkdownComponents = {
-  h1: ({ ...props }) => <h1 className={styles.h1} {...props} />,
-  h2: ({ ...props }) => <h2 className={styles.h2} {...props} />,
-  h3: ({ ...props }) => <h3 className={styles.h3} {...props} />,
-  h4: ({ ...props }) => <h4 className={styles.h4} {...props} />,
-  h5: ({ ...props }) => <h5 className={styles.h5} {...props} />,
-  h6: ({ ...props }) => <h6 className={styles.h6} {...props} />,
-  p: ({ ...props }) => <p className={styles.p} {...props} />,
-  ul: ({ ...props }) => <ul className={styles.ul} {...props} />,
-  ol: ({ ...props }) => <ol className={styles.ol} {...props} />,
-  li: ({ ...props }) => <li className={styles.li} {...props} />,
-  img: ({ ...props }) => <img className={styles.img} {...props} />,
-  blockquote: ({ ...props }) => (
-    <blockquote className={styles.blockquote} {...props} />
-  ),
-  code: (props: React.HTMLAttributes<HTMLElement>) => {
-    const isInline = !props.className?.includes('language-')
+  // 헤딩
+  h1: createComponent('h1', styles.h1),
+  h2: createComponent('h2', styles.h2),
+  h3: createComponent('h3', styles.h3),
+  h4: createComponent('h4', styles.h4),
+  h5: createComponent('h5', styles.h5),
+  h6: createComponent('h6', styles.h6),
+
+  // 텍스트 요소
+  p: createComponent('p', styles.p),
+  ul: createComponent('ul', styles.ul),
+  ol: createComponent('ol', styles.ol),
+  li: createComponent('li', styles.li),
+  blockquote: createComponent('blockquote', styles.blockquote),
+  pre: createComponent('pre', styles.pre),
+  a: createComponent('a', styles.a),
+  strong: createComponent('strong', styles.strong),
+  em: createComponent('em', styles.em),
+  hr: createComponent('hr', styles.hr),
+
+  // 테이블
+  table: createComponent('table', styles.table),
+  th: createComponent('th', styles.th),
+  td: createComponent('td', styles.td),
+  tr: createComponent('tr', styles.tr),
+
+  // 이미지
+  img: createComponent('img', styles.img),
+
+  // 코드 (특수 처리 필요)
+  code: function CodeComponent({
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLElement>) {
+    const isInline = !className?.includes('language-')
     return isInline ? (
-      <code className={styles.code} {...props} />
+      <code className={cn(styles.code, className)} {...props} />
     ) : (
-      <code {...props} />
+      <code className={className} {...props} />
     )
   },
-  pre: ({ ...props }) => <pre className={styles.pre} {...props} />,
-  a: ({ ...props }) => <a className={styles.a} {...props} />,
-  strong: ({ ...props }) => <strong className={styles.strong} {...props} />,
-  em: ({ ...props }) => <em className={styles.em} {...props} />,
-  hr: ({ ...props }) => <hr className={styles.hr} {...props} />,
-  table: ({ ...props }) => <table className={styles.table} {...props} />,
-  th: ({ ...props }) => <th className={styles.th} {...props} />,
-  td: ({ ...props }) => <td className={styles.td} {...props} />,
-  tr: ({ ...props }) => <tr className={styles.tr} {...props} />,
 }


### PR DESCRIPTION
## 📌 개요
MarkdownComponents.tsx를 리팩토링 합니다.

## 🔧 작업 내용
- 헬퍼 함수의 사용으로 중복 코드를 개선
- cn의 사용으로 확장성을 증가

## 📎 관련 이슈
closes #206 
