### PR TITLE
feat: 지원자 상세 모달 구현

### DIFF
--- a/src/components/commons/StatusBadge.tsx
+++ b/src/components/commons/StatusBadge.tsx
@@ -1,14 +1,10 @@
 import Badge from '@src/components/commons/Badge'
+import { STATUS_MAP } from '@src/constants/applicant'
+import { type ApplicantStatus } from '@src/types/applicant'
 
-export type Status = 'approved' | 'pending' | 'rejected'
-
-const STATUS_MAP: Record<Status, { text: string; cls: string }> = {
-  approved: { text: '승인됨', cls: 'bg-success-100 text-success-800' },
-  pending: { text: '대기중', cls: 'bg-primary-100 text-primary-700' },
-  rejected: { text: '거절됨', cls: 'bg-danger-100 text-danger-800' },
-}
-
-export default function StatusBadge({ status }: { status: Status }) {
+export default function StatusBadge({ status }: { status: ApplicantStatus }) {
   const parsedStatus = STATUS_MAP[status]
-  return <Badge badgeTitle={parsedStatus.text} className={parsedStatus.cls} />
+  return (
+    <Badge badgeTitle={parsedStatus.text} className={parsedStatus.className} />
+  )
 }

--- a/src/components/commons/button/buttonClass.ts
+++ b/src/components/commons/button/buttonClass.ts
@@ -15,6 +15,8 @@ export const buttonClass = cva(
           'bg-transparent text-gray-700 hover:bg-gray-100 active:bg-gray-200 disabled:bg-transparent',
         danger:
           'bg-danger-500 text-white hover:bg-danger-600 active:bg-danger-800 disabled:bg-danger-500',
+        success:
+          'bg-success-500 text-white hover:bg-success-600 active:bg-success-800 disabled:bg-success-500',
       },
       size: {
         sm: 'px-3 py-2 text-sm rounded-md',

--- a/src/components/recruitment-manage/components/ApplicantCard.tsx
+++ b/src/components/recruitment-manage/components/ApplicantCard.tsx
@@ -5,29 +5,13 @@ import InfoRow from './InfoRow'
 import { formatDate } from '@utils/date'
 import StatusBadge from '@components/commons/StatusBadge'
 import { useCallback, memo } from 'react'
-
-export type ApplicantStatus = 'pending' | 'approved' | 'rejected'
-
-export interface Applicant {
-  id: string | number // 상세 모달 API 호출용으로 필요
-  name: string
-  gender: '남성' | '여성'
-  avatarUrl?: string
-  appliedAt: string
-  availability: string
-  hasExp: boolean
-  status: ApplicantStatus
-}
+import type { Applicant } from '@src/types/applicant'
+import { getExpBadge } from '@src/constants/applicant'
 
 interface Props {
   data: Applicant
   onClick?: (applicant: Applicant) => void
 }
-
-const EXP_BADGE = {
-  true: { title: '경험 있음', className: 'bg-success-100 text-success-800' },
-  false: { title: '경험 없음', className: 'bg-gray-200 text-gray-800' },
-} as const
 
 export default memo(function ApplicantCard({ data, onClick }: Props) {
   const {
@@ -41,8 +25,7 @@ export default memo(function ApplicantCard({ data, onClick }: Props) {
     status,
   } = data
 
-  const { title: expTitle, className: badgeClass } =
-    EXP_BADGE[String(hasExp) as 'true' | 'false']
+  const { title: expTitle, className: badgeClass } = getExpBadge(hasExp)
 
   const handleClick = useCallback(() => onClick?.(data), [onClick, data])
 

--- a/src/components/recruitment-manage/components/ApplicantDetailModal.tsx
+++ b/src/components/recruitment-manage/components/ApplicantDetailModal.tsx
@@ -1,0 +1,59 @@
+import Button from '@src/components/commons/button/Button'
+import Modal from '@src/components/commons/modal'
+import { Check, X as XIcon } from 'lucide-react'
+import ApplicantProfile from './ApplicantProfile'
+import type { ApplicantDetail } from '@src/types/applicant'
+import DetailSection from './DetailSection'
+
+interface ApplicantDetailModalProps {
+  data: ApplicantDetail
+  open: boolean
+  onClose: () => void
+  title: string
+}
+
+export default function ApplicantDetailModal({
+  data,
+  open,
+  onClose,
+  title = '지원자 상세 모달',
+}: ApplicantDetailModalProps) {
+  const showActions = data.status !== 'approved'
+  return (
+    <Modal open={open} onClose={onClose} size="md" closeOnOutsideClick={true}>
+      <Modal.Header onClose={onClose}>
+        <h2 className="truncate text-xl font-semibold text-gray-900">
+          {title}
+        </h2>
+      </Modal.Header>
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-4">
+        <ApplicantProfile data={data} />
+        <DetailSection title="자기소개">{data.intro}</DetailSection>
+        <DetailSection title="지원 동기">{data.motive}</DetailSection>
+        <DetailSection title="스터디 목표">{data.goal}</DetailSection>
+        <DetailSection title="가능한 시간대">{data.availability}</DetailSection>
+        {data.hasExp && (
+          <DetailSection title="경험 상세">{data.expDetail}</DetailSection>
+        )}
+      </div>
+      {showActions && (
+        <Modal.Footer>
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              buttonInnerText="거절"
+              icon={XIcon}
+              iconSize="sm"
+              variant="danger"
+            />
+            <Button
+              buttonInnerText="승인"
+              icon={Check}
+              iconSize="sm"
+              variant="success"
+            />
+          </div>
+        </Modal.Footer>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/recruitment-manage/components/ApplicantProfile.tsx
+++ b/src/components/recruitment-manage/components/ApplicantProfile.tsx
@@ -1,0 +1,29 @@
+import StatusBadge from '@src/components/commons/StatusBadge'
+import Avatar from '../common/Avatar'
+import type { ApplicantDetail } from '@src/types/applicant'
+
+export default function ApplicantProfile({ data }: { data: ApplicantDetail }) {
+  const { avatarUrl, name, gender, status, appliedAt } = data
+  return (
+    <article className="w-full rounded-xl bg-gray-50 px-3 py-4">
+      <div className="grid grid-cols-[48px_2fr_6fr] gap-2">
+        <div className="flex items-center justify-center">
+          <Avatar size="lg" src={avatarUrl} alt={name} />
+        </div>
+        <div className="flex flex-col items-start justify-center">
+          <h4 className="font-bold"> {name} </h4>
+          <p className="text-sm text-gray-600"> {gender} </p>
+        </div>
+        <div className="flex flex-col items-end justify-center gap-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm text-gray-600"> 지원 상태</p>
+            <StatusBadge status={status} />
+          </div>
+
+          <p className="text-sm text-gray-600"> 지원 일시</p>
+          <p className="text-sm font-bold">{appliedAt}</p>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/src/components/recruitment-manage/components/DetailSection.tsx
+++ b/src/components/recruitment-manage/components/DetailSection.tsx
@@ -1,0 +1,17 @@
+interface DetailSectionProps {
+  title: string
+  children?: React.ReactNode
+}
+
+export default function DetailSection({ title, children }: DetailSectionProps) {
+  if (!children) return null
+
+  return (
+    <section className="w-full">
+      <h4 className="text-sm font-bold">{title}</h4>
+      <div className="text-md rounded-xl bg-gray-50 px-3 py-4 text-gray-700">
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/src/components/recruitment-manage/components/ManageApplicantsModal.tsx
+++ b/src/components/recruitment-manage/components/ManageApplicantsModal.tsx
@@ -1,5 +1,6 @@
 import Modal from '@components/commons/modal'
-import ApplicantCard, { type Applicant } from './ApplicantCard'
+import ApplicantCard from './ApplicantCard'
+import type { Applicant } from '@src/types/applicant'
 
 interface Props {
   open: boolean

--- a/src/components/recruitment-manage/components/RecManageList.tsx
+++ b/src/components/recruitment-manage/components/RecManageList.tsx
@@ -1,13 +1,21 @@
 import JobPostCard from '@components/commons/JobPostCard'
-import { useNavigate } from 'react-router-dom'
 import { jobPosts } from '@mock/jobPosts'
 import { EmptyState } from '@src/components/commons/EmptyState'
 import { EMPTY_MESSAGES } from '@src/constants/ui'
+import { useState } from 'react'
+import ManageApplicantsModal from './ManageApplicantsModal'
+import { dummyApplicants } from '@src/mock/applicants'
 
 type CardProps = Parameters<typeof JobPostCard>[0]
 
 export default function RecManageList() {
-  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const [selectedPostId, setSelectedPostId] = useState<number | null>(null)
+
+  const handleOpenApplicants = (postId: number) => {
+    setSelectedPostId(postId)
+    setOpen(true)
+  }
 
   const items: CardProps[] = jobPosts.map((post) => ({
     post: {
@@ -16,7 +24,7 @@ export default function RecManageList() {
     },
     editTo: `/recruitment/${post.id}/edit`,
     applyLabel: '지원 내역',
-    onClickApply: () => navigate(`/recruitment/create`),
+    onClickApply: () => handleOpenApplicants(post.id),
   }))
 
   return (
@@ -40,6 +48,16 @@ export default function RecManageList() {
           iconContainerClassName="bg-primary-50 rounded-full w-20 h-20 flex items-center justify-center"
         />
       </ul>
+      {selectedPostId !== null && (
+        <ManageApplicantsModal
+          open={open}
+          onClose={() => setOpen(false)}
+          title={
+            jobPosts.find((p) => p.id === selectedPostId)?.title ?? '공고 제목'
+          }
+          applicants={dummyApplicants} // 목데이터 or API 호출 결과
+        />
+      )}
     </section>
   )
 }

--- a/src/constants/applicant.ts
+++ b/src/constants/applicant.ts
@@ -1,0 +1,21 @@
+import type { ApplicantStatus } from '@src/types/applicant'
+
+export const STATUS_MAP: Record<
+  ApplicantStatus,
+  { text: string; className: string }
+> = {
+  approved: { text: '승인됨', className: 'bg-success-100 text-success-800' },
+  pending: { text: '대기중', className: 'bg-primary-100 text-primary-700' },
+  rejected: { text: '거절됨', className: 'bg-danger-100 text-danger-800' },
+}
+
+export const EXP_BADGE = {
+  true: { title: '경험 있음', className: 'bg-success-100 text-success-800' },
+  false: { title: '경험 없음', className: 'bg-gray-200 text-gray-800' },
+} as const
+
+type ExpKey = keyof typeof EXP_BADGE
+
+export function getExpBadge(hasExp: boolean) {
+  return EXP_BADGE[String(hasExp) as ExpKey]
+}

--- a/src/mock/applicants.ts
+++ b/src/mock/applicants.ts
@@ -1,4 +1,4 @@
-import type { Applicant } from '@src/components/recruitment-manage/components/ApplicantCard'
+import type { Applicant, ApplicantDetail } from '@src/types/applicant'
 
 export const dummyApplicants: Applicant[] = [
   {
@@ -75,5 +75,64 @@ export const dummyApplicants: Applicant[] = [
     availability: '주 3회 이상 참여 가능',
     hasExp: true,
     status: 'pending',
+  },
+]
+
+export const dummyApplicants2: ApplicantDetail[] = [
+  {
+    id: 1,
+    name: '홍길동',
+    gender: '남성',
+    avatarUrl: 'https://i.pravatar.cc/150?img=3',
+    appliedAt: '2025-09-02T14:30:00',
+    availability: '평일 저녁 7~10시, 주말 오후 시간대 참여 가능합니다.',
+    hasExp: true,
+    status: 'pending',
+    intro: '안녕하세요, 열정적인 개발자 홍길동입니다.',
+    motive:
+      '프론트엔드 실력을 더 키우고 싶어서 지원했습니다. 프론트엔드 실력을 더 키우고 싶어서 지원했습니다프론트엔드 실력을 더 키우고 싶어서 지원했습니다프론트엔드 실력을 더 키우고 싶어서 지원했습니다프론트엔드 실력을 더 키우고 싶어서 지원했습니다',
+    goal: '팀원들과 협업하며 실무 감각을 익히는 것이 목표입니다.',
+    expDetail: '작년에 사이드 프로젝트로 2개의 스터디를 진행했습니다.',
+  },
+  {
+    id: 2,
+    name: '김민지',
+    gender: '여성',
+    avatarUrl: 'https://i.pravatar.cc/150?img=5',
+    appliedAt: '2025-09-01T11:15:00',
+    availability: '화요일, 목요일 저녁 7~10시',
+    hasExp: true,
+    status: 'approved',
+    intro: '디자인과 개발을 함께 배우고 있는 김민지입니다.',
+    motive: '풀스택 역량을 기르고 싶습니다.',
+    goal: '작은 서비스라도 직접 기획부터 개발까지 완성하고 싶습니다.',
+    expDetail: '대학교에서 1년간 스터디 운영 경험이 있습니다.',
+  },
+  {
+    id: 3,
+    name: '박개발자',
+    gender: '남성',
+    appliedAt: '2025-08-30T16:45:00',
+    availability: '주 3회 이상 참여 가능',
+    hasExp: false,
+    status: 'rejected',
+    intro: '개발을 막 시작한 박개발자입니다.',
+    motive: '꾸준히 공부하는 습관을 들이고 싶어서 신청했습니다.',
+    goal: '기초 실력을 튼튼히 다지고 싶습니다.',
+    expDetail: '스터디 경험은 아직 없습니다.',
+  },
+  {
+    id: 4,
+    name: '정동근',
+    gender: '남성',
+    avatarUrl: 'https://i.pravatar.cc/150?img=7',
+    appliedAt: '2025-08-30T16:45:00',
+    availability: '주 3회 이상 참여 가능',
+    hasExp: false,
+    status: 'pending',
+    intro: '안녕하세요, 동근입니다.',
+    motive: '협업 프로젝트 경험을 쌓고 싶습니다.',
+    goal: '프론트엔드 개발자로 취업 준비를 하고 있습니다.',
+    expDetail: '스터디 경험은 없지만 회사 프로젝트 경험은 있습니다.',
   },
 ]

--- a/src/pages/test-page/TestModalPage.tsx
+++ b/src/pages/test-page/TestModalPage.tsx
@@ -1,5 +1,6 @@
-import { dummyApplicants } from '@mock/applicants'
+import { dummyApplicants, dummyApplicants2 } from '@mock/applicants'
 import ApplicationModal from '@src/components/recruitment-manage/application/ApplicationModal'
+import ApplicantDetailModal from '@src/components/recruitment-manage/components/ApplicantDetailModal'
 import ManageApplicantsModal from '@src/components/recruitment-manage/components/ManageApplicantsModal'
 import { useState } from 'react'
 
@@ -7,6 +8,7 @@ import { useState } from 'react'
 export default function TestApplicationModalPage() {
   const [openApplication, setOpenApplication] = useState(false)
   const [openManage, setOpenManage] = useState(false)
+  const [openApplicationDetail, setOpenApplicationDetail] = useState(false)
 
   return (
     <div className="space-x-4 p-8">
@@ -24,6 +26,13 @@ export default function TestApplicationModalPage() {
         지원자 관리 모달 열기
       </button>
 
+      <button
+        onClick={() => setOpenApplicationDetail(true)}
+        className="bg-danger-500 rounded px-4 py-2 text-white"
+      >
+        지원자 상세 정보
+      </button>
+
       {/* 지원서 작성 모달 */}
       <ApplicationModal
         open={openApplication}
@@ -37,6 +46,13 @@ export default function TestApplicationModalPage() {
         onClose={() => setOpenManage(false)}
         title="Unity 게임 개발 프로젝트 팀원 모집"
         applicants={dummyApplicants}
+      />
+      {/* 지원자 관리 모달 */}
+      <ApplicantDetailModal
+        open={openApplicationDetail}
+        onClose={() => setOpenApplicationDetail(false)}
+        title="지원자 상세 정보"
+        data={dummyApplicants2[1]}
       />
     </div>
   )

--- a/src/types/applicant.ts
+++ b/src/types/applicant.ts
@@ -1,0 +1,19 @@
+export type ApplicantStatus = 'pending' | 'approved' | 'rejected'
+
+export interface Applicant {
+  id: number
+  name: string
+  gender: '남성' | '여성'
+  avatarUrl?: string
+  appliedAt: string
+  availability: string
+  hasExp: boolean
+  status: ApplicantStatus
+}
+
+export interface ApplicantDetail extends Applicant {
+  intro: string
+  motive: string
+  goal: string
+  expDetail: string
+}


### PR DESCRIPTION
## 📌 개요

- 공고 관리 페이지에서 지원 현황 관리 모달 및 지원자 상세 모달을 연결하기 위한 기본 구조를 구현

## 🔧 작업 내용

- [ ] Applicant / ApplicantDetail 타입 정의 및 상수 분리 (types/applicant.ts)
- [ ] StatusBadge / ApplicantCard / ApplicantProfile / DetailSection 등 컴포넌트 리팩토링 및 분리
- [ ] ApplicantDetailModal 구현 (지원자 상세 정보 표시 + 승인/거절 버튼 조건부 렌더링)
- [ ] ManageApplicantsModal 연결 (공고별 지원자 목록 확인 가능)
- [ ] RecManageList → ManageApplicantsModal 연동 (JobPostCard에서 “지원 내역” 버튼 클릭 시 모달 오픈)
- [ ] 목데이터 (dummyApplicants, dummyApplicants2) 추가

## 📎 관련 이슈

closes #201 

## 📸 스크린샷 (선택)

### 승인 완료된 인원 ( 버튼 제외 모달 )
<img width="962" height="785" alt="image" src="https://github.com/user-attachments/assets/4e8c5af6-fb01-45c9-876a-8cbb2d961cd7" />

### 승인 대기중 인원 ( 버튼 포함 모달 )
<img width="766" height="747" alt="image" src="https://github.com/user-attachments/assets/5bcced04-c777-48bd-b0c5-dee02c61e4c1" />

### 공고 관리 페이지 모달 연결
<img width="1239" height="744" alt="image" src="https://github.com/user-attachments/assets/9f804e2b-4490-48cc-aa6c-496c9d897c0e" />


## 💬 리뷰어 참고 사항

- 현재는 목데이터 기반으로 연결했으며, 이후 실제 API 연동이 필요
- 승인/거절 버튼 클릭 시 동작(API 호출) 부분은 후속 작업 예정