### PR TITLE
feat: 리다이렉트 경로 세팅

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,88 @@
+import axios, { AxiosError, type AxiosRequestConfig } from 'axios'
+
+export const API_BASE_URL = 'https://ozcoding.site'
+
+export const api = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: true,
+})
+
+// 액세스 토큰: 메모리에만 보관
+let accessToken: string | null = null
+export const setAccessToken = (token: string | null) => {
+  accessToken = token
+}
+
+// 요청마다 Authorization 부착
+api.interceptors.request.use((config) => {
+  if (accessToken) {
+    config.headers = config.headers ?? {}
+    config.headers.Authorization = `Bearer ${accessToken}`
+  }
+  return config
+})
+
+/* Shared Promise refresh
+ *  - 만약에 한 페이지에서 여러 401 요청이 오는 경우에 모든 요청에 대한 refresh을 처리하지 않음.
+ *  - 첫 번째 401에 대한 요청에만 날리고, 다른 401 요청에 대해서는 같은 Promise를 await으로 기다림.
+ *  - token이 발급되면 그 내용으로 다시 api 요청하는 방식
+ */
+let refreshPromise: Promise<string | null> | null = null
+
+// 리프래시토큰 재발급 함수
+async function doRefresh(): Promise<string | null> {
+  try {
+    const res = await axios.post<{ access: string }>(
+      `${API_BASE_URL}/auth/refresh`,
+      {},
+      { withCredentials: true }
+    )
+    const token = res.data?.access ?? null
+    setAccessToken(token)
+    return token
+  } catch {
+    setAccessToken(null)
+    return null
+  }
+}
+
+// refreshPromise를 생성/재사용/해체하는 역할을 하는 함수
+async function getOrCreateRefresh(): Promise<string | null> {
+  if (!refreshPromise) {
+    refreshPromise = doRefresh().finally(() => {
+      refreshPromise = null // 끝나면 초기화를 하여 다음 401 요청에 대하여 새로운 Promise를 생성시킴.
+    })
+  }
+  return refreshPromise
+}
+
+// 401 공통 처리
+api.interceptors.response.use(
+  (res) => res,
+  async (error: AxiosError) => {
+    const originalAPICall = error.config as
+      | (AxiosRequestConfig & { _retry?: boolean })
+      | undefined
+    const status = error.response?.status
+
+    if (status === 401 && originalAPICall && !originalAPICall._retry) {
+      originalAPICall._retry = true
+
+      const token = await getOrCreateRefresh()
+
+      if (token) {
+        // If 토큰이 발급이 되면, 원래 진행하려던 API 요청 시작.
+        originalAPICall.headers = originalAPICall.headers ?? {}
+        originalAPICall.headers.Authorization = `Bearer ${token}`
+        return api(originalAPICall)
+      } else {
+        // If refresh token 사용 실패: 완전 로그아웃(쿠키 제거 + 상태 초기화 + 로그인 이동)
+        const { logoutHard } = await import('../store/auth')
+        await logoutHard()
+        return Promise.reject(error)
+      }
+    }
+
+    return Promise.reject(error)
+  }
+)

--- a/src/constants/apiendpoint.ts
+++ b/src/constants/apiendpoint.ts
@@ -1,0 +1,14 @@
+export const API_END_POINTS = {
+  // 유저 상태관리용 상수
+  ME: '/users/me',
+  REFRESH: '/auth/refresh',
+  LOGOUT: '/auth/logout',
+
+  // 구인공고 관련 상수
+  RECRUITMENTS_LIST: '/recruitments', // 구인 공고 목록 조회
+  RECRUITMENTS_LIST_ME: '/recruitments/me', // 내가 등록한 스터디 구인 공고 목록 조회
+  RECRUITMENTS_CREATE: '/recruitments/create', // 구인 공고 생성
+  RECRUITMENTS_EDIT: (recruitment_uuid?: string) =>
+    `/recruitments/${recruitment_uuid}`, // 구인 공고 수정
+  RECRUITMENTS_DETAIL: (uuid: string) => `/recruitments/${uuid}`, // 구인공고 상세페이지
+} as const

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,116 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import { goLogin } from '../utils/redirect'
+import { API_END_POINTS } from '@src/constants/apiendpoint'
+import { api, setAccessToken } from '@src/api/api'
+
+export interface User {
+  id: number
+  name: string
+  email: string
+}
+
+export type RouteType = 'protected' | 'public'
+
+interface AuthState {
+  user: User | null
+  bootstrapped: boolean
+  loading: boolean
+
+  isLoggedIn: () => boolean
+
+  setUser: (u: User | null) => void
+  bootstrap: (routeType: RouteType) => Promise<void>
+  loginWithToken: (access: string) => Promise<void>
+  tryFetchMe: () => Promise<User | null>
+  logoutHard: () => Promise<void>
+}
+
+export const useAuth = create<AuthState>()(
+  devtools(
+    (set, get) => ({
+      user: null,
+      bootstrapped: false,
+      loading: false,
+
+      isLoggedIn: () => !!get().user,
+
+      setUser: (u) => set({ user: u }, false, 'auth/setUser'),
+
+      // /users/me 있으면 유저 로드(없으면 비로그인)
+      tryFetchMe: async () => {
+        try {
+          const me = await api
+            .get<User>(API_END_POINTS.ME)
+            .then(({ data }) => data)
+          return me
+        } catch {
+          set({ user: null }, false, 'auth/me:absent')
+          return null
+        }
+      },
+
+      /** 첫 진입 부트스트랩
+       *  - Public: 유저 있으면 헤더 동기화, 없어도 그냥 통과
+       *  - Protected: 유저 없으면 account 로그인 페이지로 바로 이동
+       */
+      bootstrap: async (routeType) => {
+        if (get().bootstrapped) return
+        set({ loading: true }, false, 'auth/bootstrap:start')
+
+        try {
+          const me = await get().tryFetchMe()
+          set(
+            { bootstrapped: true, loading: false },
+            false,
+            'auth/bootstrap:done'
+          )
+
+          if (routeType === 'protected' && !me) {
+            goLogin() // account 로그인으로 바로 이동
+          }
+        } catch {
+          set(
+            { user: null, bootstrapped: true, loading: false },
+            false,
+            'auth/bootstrap:fail'
+          )
+          if (routeType === 'protected') goLogin()
+        }
+      },
+
+      // 외부 로그인에서 access를 받았을 때만 사용
+      loginWithToken: async (access) => {
+        set({ loading: true }, false, 'auth/login:start')
+        try {
+          setAccessToken(access)
+          await get().tryFetchMe()
+          set({ loading: false }, false, 'auth/login:success')
+        } catch {
+          setAccessToken(null)
+          set({ user: null, loading: false }, false, 'auth/login:fail')
+          goLogin()
+        }
+      },
+
+      // 완전 로그아웃: 서버에서 refresh 쿠키 삭제 + 상태 초기화 + account 로그인 페이지로 이동
+      logoutHard: async () => {
+        set({ loading: true }, false, 'auth/logoutHard:start')
+        try {
+          await api.post(API_END_POINTS.LOGOUT)
+        } catch (error) {
+          alert(`Error: ${error}`)
+        }
+        setAccessToken(null)
+        set({ user: null, loading: false }, false, 'auth/logoutHard:done')
+        goLogin()
+      },
+    }),
+    { name: 'auth-store' }
+  )
+)
+
+// 인터셉터에서 쓸 helper
+export async function logoutHard() {
+  await useAuth.getState().logoutHard()
+}

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -1,0 +1,17 @@
+const ACCOUNT = 'https://account.ozcoding.site'
+const STUDY_GROUP = 'https://study.ozcoding.site'
+
+// 로그인 페이지로 이동
+export function goLogin() {
+  window.location.href = `${ACCOUNT}/auth/login`
+}
+
+// 회원가입 페이지로 이동
+export function goSignup() {
+  window.location.href = `${ACCOUNT}/auth/signup`
+}
+
+// 스터디 그룹 페이지로 이동
+export function goStudyGroup() {
+  window.location.href = `${STUDY_GROUP}/study-group`
+}

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -3,7 +3,8 @@ const STUDY_GROUP = 'https://study.ozcoding.site'
 
 // 로그인 페이지로 이동
 export function goLogin() {
-  window.location.href = `${ACCOUNT}/auth/login`
+  const returnTo = encodeURIComponent(window.location.href)
+  window.location.href = `${ACCOUNT}/auth/login?return_to=${returnTo}`
 }
 
 // 회원가입 페이지로 이동

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/((?!.*\\.).*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 📌 개요

현재 3개의 팀에서 사용하는 서브도메인이 각각 다르므로, 이를 <Link/> 이동 방식을 활용하여 넘어가는 방식을 사용해야만 합니다. 하단에는 각각의 팀의 서브 도메인입니다.

## 🔧 작업 내용

- [ ] 쿠키 공유 세팅: Domain=.ozcoding.site; SameSite=None; Secure; HttpOnly
- [ ] 크로스 링크는 절대 URL 사용: `ex) https://learn.ozcoding.site/jobs`
- [ ] 로그인 리디렉션: return_to 활용
- [ ] CORS + credentials: 'include' 설정

## 📎 관련 이슈

closes #202 

## 💬 리뷰어 참고 사항

- zustand의 유저 상태관리를 추가하였습니다.
- 외부의 서브도메인으로 나가는 로직 추가하였습니다.
- 아직 상단의 nav바를 작업하고 있어 로직을 붙이는 작업은 아직 진행하지 않았습니다. (추후 진행할 예정)