### PR TITLE
feat: 공고 목록 페이지 반응형 구현

### DIFF
--- a/src/components/commons/JobPostCard.tsx
+++ b/src/components/commons/JobPostCard.tsx
@@ -120,7 +120,7 @@ export default function JobPostCard({
           </div>
 
           {/* 강의 태그 */}
-          <div className="grid grid-cols-2">
+          <div className="flex items-center justify-between">
             <div className="flex flex-wrap gap-2">
               {tags.map((tag, tagIndex) => (
                 <Badge

--- a/src/components/commons/chat/ParticipantsList.tsx
+++ b/src/components/commons/chat/ParticipantsList.tsx
@@ -1,6 +1,6 @@
+import { useHorizontalScroll } from '@src/hooks/useHorizontalScroll'
 import type { Participant } from '@src/types/participants'
 import { cn } from '@utils/cn'
-import { useRef, useState } from 'react'
 
 interface ParticipantsListProps {
   participants: Participant[]
@@ -9,51 +9,12 @@ interface ParticipantsListProps {
 export default function ParticipantsList({
   participants,
 }: ParticipantsListProps) {
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const [isDown, setIsDown] = useState(false)
-  const [startX, setStartX] = useState(0)
-  const [scrollLeft, setScrollLeft] = useState(0)
-
-  const onWheel = (e: React.WheelEvent<HTMLDivElement>) => {
-    if (scrollRef.current) {
-      e.preventDefault()
-      scrollRef.current.scrollLeft += e.deltaY
-    }
-  }
-
-  const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    setIsDown(true)
-    setStartX(e.pageX - (scrollRef.current?.offsetLeft ?? 0))
-    setScrollLeft(scrollRef.current?.scrollLeft ?? 0)
-    document.body.style.userSelect = 'none'
-  }
-  const onMouseLeave = () => {
-    setIsDown(false)
-    document.body.style.userSelect = ''
-  }
-  const onMouseUp = () => {
-    setIsDown(false)
-    document.body.style.userSelect = ''
-  }
-  const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!isDown) return
-    e.preventDefault()
-    const x = e.pageX - (scrollRef.current?.offsetLeft ?? 0)
-    const walk = x - startX
-    if (scrollRef.current) {
-      scrollRef.current.scrollLeft = scrollLeft - walk
-    }
-  }
+  const { ref } = useHorizontalScroll()
 
   return (
     <div
-      ref={scrollRef}
+      ref={ref}
       className="scrollbar-hide flex cursor-grab flex-nowrap items-center gap-2 overflow-x-auto border-b border-gray-200 bg-gray-50 px-2 pt-2 pb-[9px] active:cursor-grabbing"
-      onMouseDown={onMouseDown}
-      onMouseLeave={onMouseLeave}
-      onMouseUp={onMouseUp}
-      onMouseMove={onMouseMove}
-      onWheel={onWheel}
     >
       {participants.map((participant, index) => (
         <div

--- a/src/components/recruitment-detail/recruitment-banner/RecruitmentBanner.tsx
+++ b/src/components/recruitment-detail/recruitment-banner/RecruitmentBanner.tsx
@@ -61,7 +61,7 @@ export default function RecruitmentBanner() {
     <div className="w-full rounded-xl border border-gray-200 bg-white p-8">
       <div className="flex items-start justify-between pb-6">
         <div className="flex flex-col gap-4">
-          <h2 className="text-3xl font-bold">{post.title}</h2>
+          <h2 className="line-clamp-1 text-3xl font-bold">{post.title}</h2>
           <BannerInfoList items={jobInfo} />
           <BannerTags tags={post.tags} />
         </div>

--- a/src/components/recruitment/recruitment-header/Anonymous.tsx
+++ b/src/components/recruitment/recruitment-header/Anonymous.tsx
@@ -10,6 +10,7 @@ export default function Anonymous() {
       variant="filled"
       size="lg"
       link={ROUTES.LOGIN}
+      className="whitespace-nowrap"
     />
   )
 }

--- a/src/components/recruitment/recruitment-header/LoggedIn.tsx
+++ b/src/components/recruitment/recruitment-header/LoggedIn.tsx
@@ -4,7 +4,7 @@ import { FileText as FileTextIcon, Plus as PlusIcon } from 'lucide-react'
 
 export default function LoggedIn() {
   return (
-    <div className="flex gap-3">
+    <div className="flex flex-col items-end gap-3 lg:flex-row">
       <PageLink
         pageLinkInnerText="공고 관리"
         icon={FileTextIcon}

--- a/src/components/recruitment/recruitment-header/RecruitmentHeader.tsx
+++ b/src/components/recruitment/recruitment-header/RecruitmentHeader.tsx
@@ -9,7 +9,7 @@ export default function RecruitmentHeader({
   isAuthenticated,
 }: AuthBasedRecruitmentProps) {
   return (
-    <div className="flex w-[1216px] items-center justify-between">
+    <div className="mx-auto flex w-full max-w-[1216px] items-center justify-between">
       <div>
         <h2 className="pb-2 text-3xl font-bold">스터디 구인 공고</h2>
         <p className="text-gray-600">

--- a/src/components/recruitment/recruitment-list/JobPostList.tsx
+++ b/src/components/recruitment/recruitment-list/JobPostList.tsx
@@ -24,11 +24,11 @@ export default function JobPostList({
   displayCount,
 }: JobPostListProps) {
   return (
-    <div>
-      <h4 className="w-full pb-[24px] text-xl font-semibold">
+    <div className="mx-auto w-full max-w-[1216px]">
+      <h4 className="pb-[24px] text-xl font-semibold">
         {displayText} ({displayCount})
       </h4>
-      <ul className="w-[1216px]">
+      <ul className="flex flex-col gap-2">
         {jobs.map((job) => (
           <li key={job.id} className="rounded-lg bg-white">
             <JobPostCard post={job} />

--- a/src/components/recruitment/srearch-filter-bar/SearchFilterBar.tsx
+++ b/src/components/recruitment/srearch-filter-bar/SearchFilterBar.tsx
@@ -12,7 +12,7 @@ export default function SearchFilterBar() {
   } = useFilterStore()
 
   return (
-    <div className="w-[1216px] rounded-lg border border-gray-200 bg-white p-6">
+    <div className="mx-auto w-full max-w-[1216px] rounded-lg border border-gray-200 bg-white p-6">
       <SearchBar
         onSearch={setSearchTerm}
         placeholder="공고 제목으로 검색..."

--- a/src/components/recruitment/user-recruitment/Anonymous.tsx
+++ b/src/components/recruitment/user-recruitment/Anonymous.tsx
@@ -6,53 +6,67 @@ import {
   UserPlus as UserPlusIcon,
 } from 'lucide-react'
 
-export default function Anonymous() {
+interface AnonymousInProps {
+  userStyle: string
+}
+
+export default function Anonymous({ userStyle }: AnonymousInProps) {
   return (
-    <div className="flex w-[1150px] flex-col items-center">
-      <div className="bg-primary-100 mb-3 flex h-16 w-16 items-center justify-center rounded-full">
-        <UserIcon className="text-primary-600 h-6 w-6" />
-      </div>
-      <h2 className="mb-3 text-2xl font-semibold">
-        개인 맞춤 스터디 공고를 받아보세요
-      </h2>
-      <div className="mb-6 text-center text-gray-600">
-        <p>로그인하시면 관심 분야와 수강 강의를 바탕으로 맞춤형 스터디 공고</p>
-        <p>를 추천해드립니다</p>
-      </div>
-      <div className="flex gap-4">
-        <PageLink
-          pageLinkInnerText="로그인 하기"
-          variant="filled"
-          icon={LogInIcon}
-          size="lg"
-          link={ROUTES.LOGIN}
-        />
-        <PageLink
-          pageLinkInnerText="회원가입하기"
-          icon={UserPlusIcon}
-          link={ROUTES.SIGNUP}
-          variant="outline"
-          size="base"
-        />
-      </div>
-      <div className="mt-8 flex flex-col gap-4 text-center">
-        <p className="text-sm text-gray-600">
-          로그인 후 이런 맞춤 추천을 받을 수 있어요
-        </p>
+    <div className={`${userStyle} max-w-[1216px]`}>
+      <div className={`flex flex-col items-center`}>
+        <div className="bg-primary-100 mb-3 flex h-16 w-16 items-center justify-center rounded-full">
+          <UserIcon className="text-primary-600 h-6 w-6" />
+        </div>
+        <h2 className="mb-3 text-2xl font-semibold">
+          개인 맞춤 스터디 공고를 받아보세요
+        </h2>
+        <div className="mb-6 text-center text-gray-600">
+          <p>
+            로그인하시면 관심 분야와 수강 강의를 바탕으로 맞춤형 스터디 공고
+          </p>
+          <p>를 추천해드립니다</p>
+        </div>
         <div className="flex gap-4">
-          {Array.from({ length: 3 }).map((_, index) => (
-            <Card key={index} />
-          ))}
+          <PageLink
+            pageLinkInnerText="로그인 하기"
+            variant="filled"
+            icon={LogInIcon}
+            size="lg"
+            link={ROUTES.LOGIN}
+          />
+          <PageLink
+            pageLinkInnerText="회원가입하기"
+            icon={UserPlusIcon}
+            link={ROUTES.SIGNUP}
+            variant="outline"
+            size="base"
+          />
+        </div>
+        <div className="mt-8 flex flex-col gap-4 text-center">
+          <p className="text-sm text-gray-600">
+            로그인 후 이런 맞춤 추천을 받을 수 있어요
+          </p>
+          <div className="flex gap-4">
+            <Card />
+            <Card className="hidden lg:block" />
+            <Card className="hidden xl:block" />
+          </div>
         </div>
       </div>
     </div>
   )
 }
 
+interface CardProps {
+  className?: string
+}
+
 // 예시 카드
-function Card() {
+function Card({ className }: CardProps) {
   return (
-    <div className="relative w-[370px] rounded border border-gray-200 bg-white p-4">
+    <div
+      className={`relative w-[370px] rounded border border-gray-200 bg-white p-4 ${className}`}
+    >
       <div className="mb-3 flex">
         <div className="mr-3 h-8 w-12 rounded bg-gray-100"></div>
         <div>

--- a/src/components/recruitment/user-recruitment/LoggedIn.tsx
+++ b/src/components/recruitment/user-recruitment/LoggedIn.tsx
@@ -1,11 +1,19 @@
 import JobPostCard from '@components/commons/JobPostCard'
 import { RecruitmentJobPosts } from '@mock/jobPosts'
+import { SCROLLBAR_STYLES } from '@src/constants/ui'
+import { useHorizontalScroll } from '@src/hooks/useHorizontalScroll'
+import { cn } from '@src/utils/cn'
 
-export default function LoggedIn() {
+interface LoggedInProps {
+  userStyle: string
+}
+
+export default function LoggedIn({ userStyle }: LoggedInProps) {
+  const { ref } = useHorizontalScroll()
   const userName = '김스터디' // 임시
 
   return (
-    <div className="w-[1216px]">
+    <div className={`max-w-[1306px] ${userStyle}`}>
       <div className="mb-6 flex items-center">
         <div className="mr-6 text-xl font-semibold">
           <span className="text-primary-600">{userName} </span>
@@ -15,15 +23,25 @@ export default function LoggedIn() {
           개인화 추천
         </div>
       </div>
-      <div className="grid grid-cols-3 gap-6">
-        {RecruitmentJobPosts.map((post) => (
-          <div key={post.id} className="relative">
-            <JobPostCard post={post} />
-            <div className="bg-primary-500 absolute -top-2 -right-2 flex h-8 w-8 items-center justify-center rounded-full text-sm text-white">
-              ★
+      <div
+        ref={ref}
+        className={cn(
+          'overflow-x-auto overflow-y-hidden pt-2 pb-4',
+          SCROLLBAR_STYLES
+        )}
+      >
+        <div className="flex gap-6">
+          {RecruitmentJobPosts.map((post) => (
+            <div key={post.id} className="relative">
+              <div className="h-full w-[394px]">
+                <JobPostCard post={post} />
+              </div>
+              <div className="bg-primary-500 absolute -top-2 -right-2 flex h-8 w-8 items-center justify-center rounded-full text-sm text-white">
+                ★
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/src/components/recruitment/user-recruitment/UserRecruitment.tsx
+++ b/src/components/recruitment/user-recruitment/UserRecruitment.tsx
@@ -8,9 +8,11 @@ interface AuthBasedRecruitmentProps {
 export default function AuthBasedRecruitment({
   isAuthenticated,
 }: AuthBasedRecruitmentProps) {
-  return (
-    <div className="from-primary-50 border-primary-200 inline-block rounded-lg border bg-gradient-to-r to-[#FFF7ED] p-8">
-      {isAuthenticated ? <LoggedIn /> : <Anonymous />}
-    </div>
+  const userStyle =
+    'from-primary-50 border-primary-200 mx-auto inline-block w-full rounded-lg border bg-gradient-to-r to-[#FFF7ED] p-8'
+  return isAuthenticated ? (
+    <LoggedIn userStyle={userStyle} />
+  ) : (
+    <Anonymous userStyle={userStyle} />
   )
 }

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -267,3 +267,10 @@ export const STATS_TEXT = {
   FILTERED_PREFIX: '전체',
   FILTERED_SUFFIX: '중 필터링됨',
 } as const
+
+export const SCROLLBAR_STYLES =
+  '[&::-webkit-scrollbar]:h-1 ' +
+  '[&::-webkit-scrollbar-track]:bg-transparent ' +
+  '[&::-webkit-scrollbar-thumb]:bg-primary-300 ' +
+  '[&::-webkit-scrollbar-thumb]:rounded-full ' +
+  '[&::-webkit-scrollbar-thumb:hover]:bg-primary-600'

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -272,5 +272,4 @@ export const SCROLLBAR_STYLES =
   '[&::-webkit-scrollbar]:h-1 ' +
   '[&::-webkit-scrollbar-track]:bg-transparent ' +
   '[&::-webkit-scrollbar-thumb]:bg-primary-300 ' +
-  '[&::-webkit-scrollbar-thumb]:rounded-full ' +
-  '[&::-webkit-scrollbar-thumb:hover]:bg-primary-600'
+  '[&::-webkit-scrollbar-thumb]:rounded-full '

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -1,0 +1,128 @@
+import { useRef, useState, useEffect } from 'react'
+
+export function useHorizontalScroll() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isDown, setIsDown] = useState(false)
+  const [startX, setStartX] = useState(0)
+  const [scrollLeft, setScrollLeft] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    // 초기 커서 설정
+    element.classList.add('cursor-grab')
+
+    // 마우스 이벤트
+    const handleMouseDown = (e: MouseEvent) => {
+      setIsDown(true)
+      setIsDragging(false)
+      setStartX(e.pageX - element.offsetLeft)
+      setScrollLeft(element.scrollLeft)
+      document.body.classList.add('select-none')
+      element.classList.remove('cursor-grab')
+      element.classList.add('cursor-grabbing')
+    }
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDown) return
+      e.preventDefault()
+      setIsDragging(true)
+      const x = e.pageX - element.offsetLeft
+      const walk = (x - startX) * 1.5 // 스크롤 속도 조정
+      element.scrollLeft = scrollLeft - walk
+    }
+
+    const handleMouseUpOrLeave = () => {
+      setIsDown(false)
+      setIsDragging(false)
+      document.body.classList.remove('select-none')
+      element.classList.remove('cursor-grabbing')
+      element.classList.add('cursor-grab')
+    }
+
+    // 휠 이벤트
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      // Shift + 휠 또는 터치패드 가로 스크롤
+      if (e.shiftKey || Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+        element.scrollLeft += e.deltaX || e.deltaY
+      } else {
+        element.scrollLeft += e.deltaY
+      }
+    }
+
+    // 터치 이벤트
+    const handleTouchStart = (e: TouchEvent) => {
+      setIsDown(true)
+      setIsDragging(false)
+      setStartX(e.touches[0].pageX - element.offsetLeft)
+      setScrollLeft(element.scrollLeft)
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!isDown) return
+      e.preventDefault()
+      setIsDragging(true)
+      const x = e.touches[0].pageX - element.offsetLeft
+      const walk = (x - startX) * 1.5
+      element.scrollLeft = scrollLeft - walk
+    }
+
+    const handleTouchEnd = () => {
+      setIsDown(false)
+      setIsDragging(false)
+    }
+
+    // 클릭 이벤트 (드래그 후 클릭 방지)
+    const handleClick = (e: MouseEvent) => {
+      if (isDragging) {
+        e.preventDefault()
+        e.stopPropagation()
+      }
+    }
+
+    // 이벤트 리스너 등록
+    element.addEventListener('mousedown', handleMouseDown)
+    element.addEventListener('mousemove', handleMouseMove)
+    element.addEventListener('mouseup', handleMouseUpOrLeave)
+    element.addEventListener('mouseleave', handleMouseUpOrLeave)
+    element.addEventListener('wheel', handleWheel, { passive: false })
+    element.addEventListener('touchstart', handleTouchStart)
+    element.addEventListener('touchmove', handleTouchMove, { passive: false })
+    element.addEventListener('touchend', handleTouchEnd)
+    element.addEventListener('click', handleClick, true)
+
+    // 글로벌 마우스업 이벤트
+    const handleGlobalMouseUp = () => {
+      if (isDown) {
+        setIsDown(false)
+        setIsDragging(false)
+        document.body.classList.remove('select-none')
+        if (element) {
+          element.classList.remove('cursor-grabbing')
+          element.classList.add('cursor-grab')
+        }
+      }
+    }
+    document.addEventListener('mouseup', handleGlobalMouseUp)
+
+    return () => {
+      // 이벤트 리스너 정리
+      element.removeEventListener('mousedown', handleMouseDown)
+      element.removeEventListener('mousemove', handleMouseMove)
+      element.removeEventListener('mouseup', handleMouseUpOrLeave)
+      element.removeEventListener('mouseleave', handleMouseUpOrLeave)
+      element.removeEventListener('wheel', handleWheel)
+      element.removeEventListener('touchstart', handleTouchStart)
+      element.removeEventListener('touchmove', handleTouchMove)
+      element.removeEventListener('touchend', handleTouchEnd)
+      element.removeEventListener('click', handleClick, true)
+      document.removeEventListener('mouseup', handleGlobalMouseUp)
+      document.body.classList.remove('select-none')
+    }
+  }, [isDown, startX, scrollLeft, isDragging])
+
+  return { ref, isDragging }
+}

--- a/src/pages/RecruitmentDetailPage.tsx
+++ b/src/pages/RecruitmentDetailPage.tsx
@@ -7,7 +7,7 @@ import RecuitmentLecture from '@src/components/recruitment-detail/recuitment-lec
 export default function RecruitmentDetailPage() {
   return (
     <div className="flex flex-col items-center">
-      <div className="w-[896px] p-8">
+      <div className="max-w-[896px] p-8 sm:px-16">
         <div className="w-full pb-6">
           <BackButton />
         </div>

--- a/src/pages/RecruitmentPage.tsx
+++ b/src/pages/RecruitmentPage.tsx
@@ -10,11 +10,11 @@ export default function RecruitmentPage() {
   const toggleAuth = () => setIsAuthenticated((prev) => !prev)
 
   return (
-    <div className="flex w-full flex-col items-center justify-center gap-8">
+    <div className="flex w-full flex-col justify-center gap-8 px-4 sm:px-16">
       {/* 로그인, 로그아웃 확인용 임시 버튼 */}
       <button
         onClick={toggleAuth}
-        className="mb-6 rounded-lg bg-blue-500 px-6 py-2 text-white transition hover:bg-blue-600"
+        className="mb-6 max-w-[200px] rounded-lg bg-blue-500 px-6 py-2 text-white transition hover:bg-blue-600"
       >
         {isAuthenticated ? '로그아웃 상태로 전환' : '로그인 상태로 전환'}
       </button>


### PR DESCRIPTION
## 📌 개요
공고 목록 페이지 및 상세페이지를 반응형으로 구현합니다.

## 🔧 작업 내용
- 가로 스크롤 훅 구현
- 공고 페이지 반응형 구현
- 공고 상세페이지 반응형 구현

## 📎 관련 이슈
closes #212

## 📸 스크린샷 
<img width="785" height="918" alt="image" src="https://github.com/user-attachments/assets/e8fa2251-94cc-4ad8-b08c-79ba098a9219" />

## 💬 리뷰어 참고 사항
- 강의 카드 너비가 작으면 태그가 일렬로 정리되는 오류를 수정하였습니다.
- 채팅 가로스크롤 코드를 만든 훅으로 교체해주었습니다.