### PR TITLE
refactor: 마크다운 supabase와 임시 연결 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mswjs/interceptors": "^0.39.6",
+        "@supabase/supabase-js": "^2.58.0",
         "@tailwindcss/vite": "^4.1.10",
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
@@ -30,6 +31,7 @@
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
+        "uuid": "^13.0.0",
         "zod": "^4.1.8",
         "zustand": "^5.0.5"
       },
@@ -2217,6 +2219,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -2851,11 +2927,16 @@
       "version": "24.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
       "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.12",
@@ -2888,6 +2969,15 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.42.0",
@@ -9776,6 +9866,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -9980,7 +10076,6 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -10122,6 +10217,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -10270,6 +10378,22 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10414,6 +10538,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@mswjs/interceptors": "^0.39.6",
+    "@supabase/supabase-js": "^2.58.0",
     "@tailwindcss/vite": "^4.1.10",
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
@@ -34,6 +35,7 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
+    "uuid": "^13.0.0",
     "zod": "^4.1.8",
     "zustand": "^5.0.5"
   },

--- a/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
+++ b/src/components/recruitment-create/RecCreateAdditionalInfo.tsx
@@ -1,14 +1,17 @@
 import RecEditPriceInput from '../recruitment-edit/RecEditPriceInput'
-import { FileUploadBox } from './FileUploadBox'
+import { SupabaseFileuploader } from './SupabaseFileUploader'
 import TagSection from './tag-ui/TagSection'
+import { useState } from 'react'
 
 interface PresetFile {
-  id: number
+  id: string
   name: string
   url: string
+  key?: string
 }
 
 interface Props {
+  draftId: string
   derivedPrice?: string
   override: string | null
   onChangeOverride: (raw: string) => void
@@ -19,10 +22,11 @@ const formatPrice = (s?: string) =>
   s ? new Intl.NumberFormat('ko-KR').format(Number(s)) : ''
 
 export default function RecCreateAdditionalInfo({
+  draftId,
   derivedPrice = '',
   override,
   onChangeOverride,
-  defaultFiles,
+  defaultFiles = [],
 }: Props) {
   const inputValue = override === null ? derivedPrice : override
   const valueForInput = override === '' ? '' : inputValue
@@ -31,6 +35,8 @@ export default function RecCreateAdditionalInfo({
   if (override === '') {
     placeholder = formatPrice(derivedPrice) || '금액 입력'
   }
+
+  const [attachments, setAttachments] = useState<PresetFile[]>(defaultFiles)
 
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
@@ -48,11 +54,16 @@ export default function RecCreateAdditionalInfo({
       <div className="mt-6">
         <TagSection />
       </div>
+
       <div className="mt-6">
         <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
           참고 파일 업로드 (선택사항)
         </label>
-        <FileUploadBox defaultFiles={defaultFiles} />
+        <SupabaseFileuploader
+          draftId={draftId}
+          defaultFiles={attachments}
+          onChange={(files) => setAttachments(files)}
+        />
       </div>
     </div>
   )

--- a/src/components/recruitment-create/RecCreateContentSection.tsx
+++ b/src/components/recruitment-create/RecCreateContentSection.tsx
@@ -4,14 +4,15 @@ import { STUDY_INTRO_PLACEHOLDER } from '@src/constants/studyintroplaceholder'
 import { countMdImages } from './markdown-ui/mdImages'
 
 interface RecCreateContentSectionProps {
+  draftId: string
   onContentChange?: (v: string) => void
 }
 
 const MAX_IMAGES = 5
-
 const PLACEHOLDER = STUDY_INTRO_PLACEHOLDER
 
 export default function RecCreateContentSection({
+  draftId,
   onContentChange,
 }: RecCreateContentSectionProps) {
   const [markDown, setMarkDown] = useState('')
@@ -20,6 +21,7 @@ export default function RecCreateContentSection({
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
       <p className="text-[20px] leading-7 font-semibold">공고 내용</p>
+
       <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
         공고 내용
         <span className="text-danger-500" aria-label="필수 입력">
@@ -27,24 +29,29 @@ export default function RecCreateContentSection({
           *
         </span>
       </label>
+
       <div className="flex justify-between text-[12px] font-normal text-gray-500">
         <p>마크다운 문법을 사용할 수 있습니다</p>
         <p>
           이미지 {usedCount}/{MAX_IMAGES}개
         </p>
       </div>
+
       <label className="mt-2 mb-2 block text-sm leading-5 font-medium text-gray-700">
         스터디 그룹 소개(선택사항)
       </label>
+
       <StudyIntroMarkdown
+        draftId={draftId}
         value={markDown}
-        onChange={(v) => {
+        onChange={(v: string) => {
           setMarkDown(v)
           onContentChange?.(v)
         }}
         placeholder={PLACEHOLDER}
         height={320}
       />
+
       <div className="pt-2 text-[12px] leading-4 font-normal text-gray-500">
         <p>• 마크다운 문법: **굵게**, *기울임*, # 제목, - 목록 등</p>
         <p>• 이미지 추가: ![설명](이미지URL) - 최대 5개, 각 5MB 이하</p>

--- a/src/components/recruitment-create/StudyIntroMarkdown.tsx
+++ b/src/components/recruitment-create/StudyIntroMarkdown.tsx
@@ -3,22 +3,25 @@ import MdToolbar from './markdown-ui/MdToolbar'
 import MdPreview from './markdown-ui/MdPreview'
 import MdFooter from './markdown-ui/MdFooter'
 import { useMdCommands } from './markdown-ui/useMdCommands'
-import { useImageUploader } from './markdown-ui/useImageUploader'
 import { useMdImageDnDPaste } from './markdown-ui/useMdImageDnDPaste'
 import { countMdImages } from './markdown-ui/mdImages'
 import { useToast } from '@components/commons/toast'
+import { useSupaBaseUploader } from './markdown-ui/useSupaBaseUploader'
 
 interface StudyIntroProps {
+  draftId: string
   value: string
   onChange: (v: string) => void
   placeholder?: string
   height?: number
 }
+
 const MAX_IMAGES = 5
 const PLACEHOLDER =
   '# 스터디 소개\nReact 실무 프로젝트를 함께 진행할 팀원을 모집합니다!\n\n## 스터디 내용\n- React 기초부터 실무 적용까지\n- 실제 프로젝트 개발 경험\n- 코드 리뷰 및 피드백'
 
 export default function StudyIntroMarkdown({
+  draftId,
   value,
   onChange,
   placeholder = PLACEHOLDER,
@@ -38,8 +41,8 @@ export default function StudyIntroMarkdown({
 
   const toast = useToast()
 
-  const { upload, isUploading } = useImageUploader({
-    mode: 'mock',
+  const { upload, isUploading } = useSupaBaseUploader({
+    draftId,
     maxSize: 10 * 1024 * 1024,
     onError: (m) =>
       toast.error({
@@ -131,7 +134,6 @@ export default function StudyIntroMarkdown({
               title: '이미지 파일만 업로드',
               content: 'PNG, JPG, GIF, WEBP 등을 지원해요.',
             })
-            // 텍스트 붙여넣기는 방해하지 않으므로 여기선 preventDefault 안 함
           }
         }
       }
@@ -174,7 +176,7 @@ export default function StudyIntroMarkdown({
         {views[tab]}
 
         <MdFooter>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 text-[12px]">
             <span>마크다운 문법을 사용할 수 있습니다.</span>
             <strong>**굵게**</strong>
             <em>*기울임*</em>

--- a/src/components/recruitment-create/SupabaseFileUploader.tsx
+++ b/src/components/recruitment-create/SupabaseFileUploader.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useMemo } from 'react'
+import { FileUp } from 'lucide-react'
+import DottedBox from './uploadbox-ui/DottedBox'
+import FileList from './uploadbox-ui/FileList'
+import useUploader from './uploadbox-ui/useUploader'
+import { useToast } from '@components/commons/toast'
+import { useSupabaseFileStorage } from './useSupabaseFileStorage'
+
+const MAX_FILES = 3
+
+interface PresetFile {
+  id: string
+  name: string
+  url: string
+  key?: string
+}
+
+interface FileWithPreview extends File {
+  preview?: string
+  __preset?: boolean
+  __uploaded?: boolean
+}
+
+interface FileUploadBoxProps {
+  draftId: string
+  defaultFiles?: PresetFile[]
+  onChange?: (files: PresetFile[]) => void
+}
+
+function dedupe(files: PresetFile[]) {
+  const seen = new Set<string>()
+  const out: PresetFile[] = []
+  for (const f of files) {
+    const k = f.key ?? `${f.url}#${f.name}`
+    if (seen.has(k)) continue
+    seen.add(k)
+    out.push(f)
+  }
+  return out
+}
+
+export function SupabaseFileuploader({
+  draftId,
+  defaultFiles = [],
+  onChange,
+}: FileUploadBoxProps) {
+  const toast = useToast()
+  const { uploadOne, removeKeys, isUploading } = useSupabaseFileStorage()
+
+  const { files, state, getRootProps, getInputProps, removeAt } = useUploader({
+    accept: { '*/*': [] },
+    maxFiles: MAX_FILES,
+    maxSize: 5 * 1024 * 1024,
+    onError: (m) => toast.error({ title: '업로드 오류', content: m }),
+  })
+
+  const adaptedPreset = useMemo<FileWithPreview[]>(
+    () =>
+      defaultFiles.map((pf) => {
+        const f = new File([''], pf.name, {
+          type: 'application/octet-stream',
+          lastModified: 0,
+        }) as FileWithPreview
+        f.preview = pf.url
+        f.__preset = true
+        return f
+      }),
+    [defaultFiles]
+  )
+
+  const combinedFiles = adaptedPreset
+
+  useEffect(() => {
+    const locals = (files as FileWithPreview[]).filter(
+      (f) => !f.__preset && !f.__uploaded
+    )
+    if (locals.length === 0) return
+
+    const capacity = MAX_FILES - defaultFiles.length
+    if (capacity <= 0) {
+      toast.warning({
+        title: '업로드 제한',
+        content: `파일은 최대 ${MAX_FILES}개까지 업로드할 수 있어요.`,
+      })
+      for (let i = files.length - 1; i >= 0; i--) removeAt(i)
+      return
+    }
+
+    const allowed = locals.slice(0, capacity)
+    const overflow = locals.length - allowed.length
+    if (overflow > 0) {
+      toast.warning({
+        title: '업로드 제한',
+        content: `최대 ${MAX_FILES}개까지 가능해서 ${overflow}개는 제외했어요.`,
+      })
+    }
+
+    ;(async () => {
+      try {
+        const uploaded: PresetFile[] = []
+        for (const f of allowed) {
+          const { key, url, name } = await uploadOne(f, draftId, 'files')
+          uploaded.push({ id: key, name, url, key })
+        }
+        const next = dedupe([...defaultFiles, ...uploaded])
+        onChange?.(next)
+      } catch (err: unknown) {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : '파일 업로드 중 오류가 발생했습니다.'
+        toast.error({ title: '업로드 실패', content: msg })
+      } finally {
+        for (let i = files.length - 1; i >= 0; i--) removeAt(i)
+      }
+    })()
+  }, [files, defaultFiles, uploadOne, draftId, removeAt, onChange, toast])
+
+  const handleRemove = async (index: number) => {
+    const target = defaultFiles[index]
+    const next = defaultFiles.filter((_, i) => i !== index)
+    onChange?.(next)
+    if (target?.key) {
+      try {
+        await removeKeys([target.key])
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return (
+    <DottedBox
+      state={state}
+      className="h-[282px] !p-0"
+      {...getRootProps({ role: 'button', tabIndex: 0 })}
+    >
+      <input {...getInputProps()} />
+
+      <div className="w-full p-6 sm:p-8">
+        <div className="text-center select-none">
+          <FileUp className="mx-auto mb-2 h-8 w-8 text-gray-500 opacity-70" />
+          <p className="text-sm font-medium text-gray-500">
+            파일을 드래그하거나 클릭하여 업로드
+          </p>
+          <p className="mt-1 text-xs text-gray-500">
+            최대 {MAX_FILES}개 파일, 각 5MB 이하
+          </p>
+          {isUploading && (
+            <p className="mt-1 text-xs text-gray-500">업로드 중…</p>
+          )}
+        </div>
+
+        {combinedFiles.length > 0 && (
+          <div className="mx-auto mt-4 max-h-48 overflow-y-auto">
+            <FileList
+              files={combinedFiles}
+              onRemove={handleRemove}
+              showPreview
+              thumbSize={24}
+              dense
+            />
+          </div>
+        )}
+      </div>
+    </DottedBox>
+  )
+}

--- a/src/components/recruitment-create/markdown-ui/useSupaBaseUploader.ts
+++ b/src/components/recruitment-create/markdown-ui/useSupaBaseUploader.ts
@@ -1,0 +1,54 @@
+import { supa } from '@src/lib/supabase'
+import { useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+
+const BUCKET = import.meta.env.VITE_SUPA_BUCKET as string
+
+export function useSupaBaseUploader({
+  maxSize = 10 * 1024 * 1024,
+  onError,
+  draftId = 'anon-draft',
+}: {
+  maxSize?: number
+  onError?: (m?: string) => void
+  draftId?: string
+}) {
+  const [isUploading, setUploading] = useState(false)
+
+  async function upload(file: File) {
+    try {
+      setUploading(true)
+      if (file.size > maxSize) throw new Error('파일 용량 제한을 초과했습니다.')
+      const ext = (file.name.split('.').pop() || 'png').toLowerCase()
+      const key = `temp/${draftId}/${uuidv4()}.${ext}`
+
+      const { error } = await supa.storage.from(BUCKET).upload(key, file, {
+        contentType: file.type,
+        upsert: false,
+      })
+      if (error) throw error
+
+      const { data } = supa.storage.from(BUCKET).getPublicUrl(key)
+      const url = `${data.publicUrl}?assetId=${encodeURIComponent(key)}`
+      return { url, key }
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'string'
+            ? err
+            : '업로드에 실패했습니다.'
+      onError?.(msg)
+      throw err
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function deleteMany(keys: string[]) {
+    if (!keys.length) return
+    await supa.storage.from(BUCKET).remove(keys)
+  }
+
+  return { upload, isUploading, deleteMany }
+}

--- a/src/components/recruitment-create/useSupabaseFileStorage.ts
+++ b/src/components/recruitment-create/useSupabaseFileStorage.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { supa } from '@src/lib/supabase'
+import { v4 as uuidv4 } from 'uuid'
+
+export interface UploadedFile {
+  key: string
+  url: string
+  name: string
+}
+
+const BUCKET = import.meta.env.VITE_SUPA_BUCKET as string
+
+export function useSupabaseFileStorage() {
+  const [isUploading, setIsUploading] = useState(false)
+
+  async function uploadOne(
+    file: File,
+    draftId: string,
+    prefix = 'files'
+  ): Promise<UploadedFile> {
+    setIsUploading(true)
+    try {
+      const ext = (file.name.split('.').pop() || 'bin').toLowerCase()
+      const key = `temp/${draftId}/${prefix}/${uuidv4()}.${ext}`
+      const { error } = await supa.storage.from(BUCKET).upload(key, file, {
+        contentType: file.type || 'application/octet-stream',
+        upsert: false,
+      })
+      if (error) throw error
+      const { data } = supa.storage.from(BUCKET).getPublicUrl(key)
+      return { key, url: data.publicUrl, name: file.name }
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  async function removeKeys(keys: string[]) {
+    if (!keys.length) return
+    await supa.storage.from(BUCKET).remove(keys)
+  }
+
+  return { uploadOne, removeKeys, isUploading }
+}

--- a/src/components/recruitment-edit/RecEditAdditionalInfo.tsx
+++ b/src/components/recruitment-edit/RecEditAdditionalInfo.tsx
@@ -1,34 +1,43 @@
-import { useEffect, useState } from 'react'
-import { FileUploadBox } from '../recruitment-create/FileUploadBox'
-import TagBox from '../recruitment-create/tag-ui/TagBox'
+import { useEffect, useMemo, useState } from 'react'
 import RecEditPriceInput from './RecEditPriceInput'
+import TagBox from '../recruitment-create/tag-ui/TagBox'
+import { SupabaseFileuploader } from '../recruitment-create/SupabaseFileUploader'
 
-interface PresetFile {
-  id: number
+interface PresetFileIn {
+  id: number | string
   name: string
   url: string
+  key?: string
 }
 
 interface RecEditAdditionalInfoProps {
+  draftId: string
   defaultPrice?: string
   onPriceChange: (raw: string) => void
-  defaultFiles?: PresetFile[]
+  defaultFiles?: PresetFileIn[]
 }
 
 export default function RecEditAdditionalInfo({
+  draftId,
   defaultPrice,
   onPriceChange,
-  defaultFiles,
+  defaultFiles = [],
 }: RecEditAdditionalInfoProps) {
   const [price, setPrice] = useState('')
+  useEffect(() => setPrice(defaultPrice ?? ''), [defaultPrice])
 
-  useEffect(() => {
-    setPrice(defaultPrice ?? '')
-  }, [defaultPrice])
+  const normalized = useMemo(
+    () => defaultFiles.map((f) => ({ ...f, id: String(f.id) })),
+    [defaultFiles]
+  )
+
+  const [attachments, setAttachments] = useState(normalized)
+  useEffect(() => setAttachments(normalized), [normalized])
+
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
       <p className="text-[20px] leading-7 font-semibold">추가 정보</p>
-      {/* 예상 결제 비용 field*/}
+
       <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
         예상 결제 비용 (원)
       </label>
@@ -38,15 +47,21 @@ export default function RecEditAdditionalInfo({
           setPrice(raw)
           onPriceChange(raw)
         }}
-      />{' '}
+      />
+
       <div className="mt-6">
         <TagBox />
       </div>
+
       <div className="mt-6">
         <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
           참고 파일 업로드 (선택사항)
         </label>
-        <FileUploadBox defaultFiles={defaultFiles} />
+        <SupabaseFileuploader
+          draftId={draftId}
+          defaultFiles={attachments}
+          onChange={setAttachments}
+        />
       </div>
     </div>
   )

--- a/src/components/recruitment-edit/RecEditContentSection.tsx
+++ b/src/components/recruitment-edit/RecEditContentSection.tsx
@@ -4,6 +4,7 @@ import { STUDY_INTRO_PLACEHOLDER } from '@src/constants/studyintroplaceholder'
 import { countMdImages } from '../recruitment-create/markdown-ui/mdImages'
 
 interface RecEditContentSectionProps {
+  draftId: string
   defaultMarkDown?: string
   onChangeMarkDown?: (md: string) => void
 }
@@ -12,6 +13,7 @@ const PLACEHOLDER = STUDY_INTRO_PLACEHOLDER
 const MAX_IMAGES = 5
 
 export default function RecEditContentSection({
+  draftId,
   defaultMarkDown,
   onChangeMarkDown,
 }: RecEditContentSectionProps) {
@@ -21,16 +23,13 @@ export default function RecEditContentSection({
     if (defaultMarkDown !== undefined) setMarkDown(defaultMarkDown)
   }, [defaultMarkDown])
 
-  const usedCount = useMemo(
-    () => countMdImages(markDown, true), // 업로드중 자리표시자까지 포함하려면 true
-    [markDown]
-  )
+  const usedCount = useMemo(() => countMdImages(markDown, true), [markDown])
 
   return (
     <div className="w-full max-w-[832px] rounded-xl border border-gray-200 bg-white p-6 text-gray-900">
       <p className="text-[20px] leading-7 font-semibold">공고 내용</p>
       <label className="mt-6 mb-2 block text-sm leading-5 font-medium text-gray-700">
-        공고 내용
+        공고 내용{' '}
         <span className="text-danger-500" aria-label="필수 입력">
           {' '}
           *
@@ -49,10 +48,11 @@ export default function RecEditContentSection({
       </label>
 
       <StudyIntroMarkdown
+        draftId={draftId}
         value={markDown}
-        onChange={(value) => {
-          setMarkDown(value)
-          onChangeMarkDown?.(value)
+        onChange={(v) => {
+          setMarkDown(v)
+          onChangeMarkDown?.(v)
         }}
         placeholder={PLACEHOLDER}
         height={320}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supa = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON!,
+  { auth: { persistSession: false } }
+)

--- a/src/pages/RecruitmentCreate.tsx
+++ b/src/pages/RecruitmentCreate.tsx
@@ -68,6 +68,7 @@ export default function RecruitmentCreate() {
         />
 
         <RecCreateAdditionalInfo
+          draftId={draftId}
           derivedPrice={derivedPrice}
           override={priceOverride}
           onChangeOverride={(raw) => setPriceOverride(raw)}

--- a/src/pages/RecruitmentCreate.tsx
+++ b/src/pages/RecruitmentCreate.tsx
@@ -4,6 +4,7 @@ import RecCreateContentSection from '@src/components/recruitment-create/RecCreat
 import RecCreateHeader from '@src/components/recruitment-create/RecCreateHeader'
 import RecCreateFooter from '@src/components/recruitment-create/RecCreateFooter'
 import { useMemo, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 import {
   getCoursesForGroup,
   sumCoursePrices,
@@ -15,18 +16,20 @@ import { useRecruitCreateForm } from '@src/hooks/useRecruitCreateForm'
 export default function RecruitmentCreate() {
   const toast = useToast()
   const navigate = useNavigate()
+  const draftId = useMemo(() => uuidv4(), [])
   const [studyGroupName, setStudyGroupName] = useState<string | undefined>()
   const [priceOverride, setPriceOverride] = useState<string | null>(null)
+
   const courses = useMemo(
     () => getCoursesForGroup(studyGroupName),
     [studyGroupName]
   )
+
   const derivedPrice = useMemo(
     () => (courses.length ? String(sumCoursePrices(courses)) : ''),
     [courses]
   )
 
-  // ── 폼 훅
   const {
     canSubmit,
     onTitleChange,
@@ -59,7 +62,10 @@ export default function RecruitmentCreate() {
           onExpectedHeadcountChange={onExpectedHeadcountChange}
         />
 
-        <RecCreateContentSection onContentChange={onContentChange} />
+        <RecCreateContentSection
+          draftId={draftId}
+          onContentChange={onContentChange}
+        />
 
         <RecCreateAdditionalInfo
           derivedPrice={derivedPrice}

--- a/src/pages/RecruitmentEdit.tsx
+++ b/src/pages/RecruitmentEdit.tsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import { useMutation } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 import { useToast } from '@components/commons/toast'
 import {
   getCoursesForGroup,
@@ -23,6 +24,9 @@ export default function RecruitmentEdit() {
   const { recruitment_uuid = 'me-1' } = useParams()
   const navigate = useNavigate()
   const toast = useToast()
+
+  const draftId = useMemo(() => uuidv4(), [])
+
   const MOCKDATA = recMockDatas[0]
   const [title, setTitle] = useState(MOCKDATA.title)
   const [groupName, setGroupName] = useState<string | undefined>(
@@ -34,6 +38,7 @@ export default function RecruitmentEdit() {
   const [deadline, setDeadline] = useState<Date | null>(MOCKDATA.deadline)
   const [markdown, setMarkdown] = useState<string>(MOCKDATA.content)
   const [priceRaw, setPriceRaw] = useState<string>('')
+
   const groupCourses = useMemo(() => getCoursesForGroup(groupName), [groupName])
   const derivedPrice = useMemo(
     () => String(sumCoursePrices(groupCourses)),
@@ -96,10 +101,12 @@ export default function RecruitmentEdit() {
           onDeadlineChange={setDeadline}
         />
         <RecEditContentSection
+          draftId={draftId}
           defaultMarkDown={markdown}
           onChangeMarkDown={setMarkdown}
         />
         <RecEditAdditionalInfo
+          draftId={draftId}
           defaultPrice={derivedPrice}
           onPriceChange={setPriceRaw}
           defaultFiles={MOCKDATA.files}


### PR DESCRIPTION
## 📌 개요

- 현재 마크다운을 올리는 api가 s3에 올리는 것만 있고, delete하는 것은 없기 때문에 이를 보완하고자 supabase와 연결하여 추가한 작업을 PR 요청.

## 🔧 작업 내용
- supabase 패키지 추가
- supabase 세팅
- 파일 업로드 연결
- 마크다운 이미지 업로드 연결
- 생성과 수정부분 둘 다 세팅

## 📎 관련 이슈

closes #236 

## 📸 스크린샷
### 1. 마크다운 이미지 업로드 
![마크다운 이미지 업로드](https://github.com/user-attachments/assets/d4eeacc8-fbc1-4234-9ccc-88f43b5fdca4)

### 2. 파일 업로드
![파일 업로드](https://github.com/user-attachments/assets/1524d921-51a4-46cb-9056-bf050844df2e)


## 💬 리뷰어 참고 사항

- 업로드한 파일을 삭제하는 기능이 구현이 되지 않아 supabase에 연결하여 작업을 진행하였습니다. 
