### PR TITLE
feat: 스터디 지원서 제출 API 연동

### DIFF
--- a/src/api/application.ts
+++ b/src/api/application.ts
@@ -1,8 +1,11 @@
 import type {
   ApplicationDetail,
   ApplicationsResponse,
+  SubmitApplicationPayload,
+  SubmitApplicationResponse,
 } from '@src/types/applicant'
 import axios from 'axios'
+import { api } from './api'
 
 export interface UpdateApplicationResponse {
   message: string
@@ -23,7 +26,7 @@ export async function getApplications(
 
 // 지원자 상세 조회
 export async function getApplicationDetail(applicationId: number) {
-  const { data } = await axios.get<ApplicationDetail>(
+  const { data } = await api.get<ApplicationDetail>(
     `/api/v1/applications/${applicationId}`
   )
   return data
@@ -31,7 +34,7 @@ export async function getApplicationDetail(applicationId: number) {
 
 // 승인
 export async function approveApplication(applicationId: number) {
-  const { data } = await axios.post<UpdateApplicationResponse>(
+  const { data } = await api.post<UpdateApplicationResponse>(
     `/api/v1/applications/${applicationId}/approve`
   )
   return data
@@ -39,8 +42,20 @@ export async function approveApplication(applicationId: number) {
 
 // 거절
 export async function rejectApplication(applicationId: number) {
-  const { data } = await axios.post<UpdateApplicationResponse>(
+  const { data } = await api.post<UpdateApplicationResponse>(
     `/api/v1/applications/${applicationId}/reject`
+  )
+  return data
+}
+
+// 지원서 제출
+export async function submitApplication(
+  recruitmentId: string,
+  payload: SubmitApplicationPayload
+) {
+  const { data } = await api.post<SubmitApplicationResponse>(
+    `/api/v1/recruitments/${recruitmentId}/applications`,
+    payload
   )
   return data
 }

--- a/src/api/tag.ts
+++ b/src/api/tag.ts
@@ -1,12 +1,12 @@
 import type { Tag } from '@src/types/tag'
-import axios from 'axios'
+import { api } from './api'
 
 export async function fetchTags(params: {
   search: string
   page: number
   size: number
 }) {
-  const res = await axios.get<{ results: Tag[]; count: number }>(
+  const res = await api.get<{ results: Tag[]; count: number }>(
     '/api/v1/recruitments/tags', // 나중에 basurl 사용하면 바꾸기
     {
       params,
@@ -16,6 +16,6 @@ export async function fetchTags(params: {
 }
 
 export async function createTag(name: string) {
-  const res = await axios.post<Tag>('/api/v1/recruitments/tags', { name })
+  const res = await api.post<Tag>('/api/v1/recruitments/tags', { name })
   return res.data
 }

--- a/src/components/recruitment-detail/recruitment-banner/RecruitmentBanner.tsx
+++ b/src/components/recruitment-detail/recruitment-banner/RecruitmentBanner.tsx
@@ -77,6 +77,7 @@ export default function RecruitmentBanner() {
         open={openApplication}
         onClose={() => setOpenApplication(false)}
         title="Unity 게임 개발 프로젝트 팀원 모집"
+        recruitmentUuid={String(post.uuid ?? post.id)}
       />
     </div>
   )

--- a/src/components/recruitment-manage/application/ApplicationModal.tsx
+++ b/src/components/recruitment-manage/application/ApplicationModal.tsx
@@ -3,12 +3,16 @@ import Modal from '@components/commons/modal'
 import { FormField, TextareaWithCounter } from '@components/commons/form'
 import { MousePointer2 as MousePointer2Icon } from 'lucide-react'
 import { useForm } from 'react-hook-form'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { useToast } from '@src/components/commons/toast'
+import { submitApplication } from '@src/api/application'
+import type { AxiosError } from 'axios'
 
 interface Props {
   open: boolean
   onClose: () => void
   title?: string
+  recruitmentUuid: string
 }
 
 interface Form {
@@ -56,7 +60,11 @@ export default function ApplicationModal({
   open,
   onClose,
   title = '공고 제목',
+  recruitmentUuid,
 }: Props) {
+  const toast = useToast()
+  const [submitting, setSubmitting] = useState(false)
+
   const {
     register,
     handleSubmit,
@@ -70,10 +78,35 @@ export default function ApplicationModal({
 
   const hasExp = watch('hasExp') ?? false
 
-  const onSubmit = (data: Form) => {
-    console.log(data)
-    reset()
-    onClose()
+  const onSubmit = async (f: Form) => {
+    setSubmitting(true)
+    try {
+      await submitApplication(recruitmentUuid, {
+        self_introduction: f.intro.trim(),
+        motivation: f.motive.trim(),
+        objective: f.goal.trim(),
+        available_time: f.availability.trim(),
+        has_study_experience: !!f.hasExp,
+        study_experience: f.hasExp ? f.expDetail?.trim() : undefined,
+      })
+
+      toast.success({ title: '제출 완료', content: '지원서가 제출되었습니다.' })
+      reset()
+      onClose()
+    } catch (e) {
+      const err = e as AxiosError<{
+        detail?: string
+        error_code?: string
+        error?: string
+      }>
+      const msg =
+        err.response?.data?.detail ??
+        err.response?.data?.error ??
+        '제출에 실패했습니다. 잠시 후 다시 시도해 주세요.'
+      toast.error({ title: '제출 실패', content: msg })
+    } finally {
+      setSubmitting(false)
+    }
   }
   const onInvalid = () => {
     const firstErrorName = Object.keys(errors)[0] as keyof Form | undefined
@@ -94,9 +127,9 @@ export default function ApplicationModal({
   useEffect(() => {
     if (!hasExp) {
       clearErrors('expDetail')
-      setValue('expDetail', '') // 내용도 초기화
+      setValue('expDetail', '') // 내용 초기화
     }
-  }, [hasExp, clearErrors])
+  }, [hasExp, clearErrors, setValue])
 
   return (
     <Modal
@@ -184,14 +217,15 @@ export default function ApplicationModal({
             onClick={handleClose}
           />
           <Button
-            buttonInnerText="지원서 제출"
+            buttonInnerText={submitting ? '제출 중…' : '지원서 제출'}
             icon={MousePointer2Icon}
             variant="primary"
             size="base"
             fontWeight="medium"
             iconClassName="rotate-[90deg]"
-            onClick={handleSubmit(onSubmit, onInvalid)}
             iconSize="sm"
+            onClick={handleSubmit(onSubmit, onInvalid)}
+            disabled={submitting}
           />
         </div>
       </Modal.Footer>

--- a/src/mock/handlers/applications.ts
+++ b/src/mock/handlers/applications.ts
@@ -1,4 +1,3 @@
-// msw/handlers/applicationHandlers.ts
 import { http, HttpResponse } from 'msw'
 import {
   dummyApplicationsPage1,
@@ -69,7 +68,7 @@ const nextCursor = (offset: number, total: number) => {
 export const applicationHandlers = [
   // 목록
   http.get(
-    '/api/v1/recruitments/:recruitmentUuid/applications',
+    'https://ozcoding.site/api/v1/recruitments/:recruitmentUuid/applications',
     ({ request }) => {
       const url = new URL(request.url)
       const offset = readCursor(url.searchParams)
@@ -83,42 +82,73 @@ export const applicationHandlers = [
   ),
 
   // 상세
-  http.get('/api/v1/applications/:applicationId', ({ params }) => {
-    const id = Number(params.applicationId)
-    const detail = detailStore[id]
-    if (!detail) {
-      return HttpResponse.json({ detail: '찾을 수 없습니다.' }, { status: 404 })
+  http.get(
+    'https://ozcoding.site/api/v1/applications/:applicationId',
+    ({ params }) => {
+      const id = Number(params.applicationId)
+      const detail = detailStore[id]
+      if (!detail) {
+        return HttpResponse.json(
+          { detail: '찾을 수 없습니다.' },
+          { status: 404 }
+        )
+      }
+      return HttpResponse.json(detail)
     }
-    return HttpResponse.json(detail)
-  }),
+  ),
 
   // 승인
-  http.post('/api/v1/applications/:applicationId/approve', ({ params }) => {
-    const id = Number(params.applicationId)
-    const t = listStore.find((a) => a.application_id === id)
-    if (!t || !detailStore[id]) {
-      return HttpResponse.json({ detail: '찾을 수 없습니다.' }, { status: 404 })
+  http.post(
+    'https://ozcoding.site/api/v1/applications/:applicationId/approve',
+    ({ params }) => {
+      const id = Number(params.applicationId)
+      const t = listStore.find((a) => a.application_id === id)
+      if (!t || !detailStore[id]) {
+        return HttpResponse.json(
+          { detail: '찾을 수 없습니다.' },
+          { status: 404 }
+        )
+      }
+      t.status = 'APPROVED'
+      detailStore[id] = { ...detailStore[id], status: 'APPROVED' }
+      return HttpResponse.json({
+        message: '지원이 승인되었습니다.',
+        status: 'APPROVED',
+      })
     }
-    t.status = 'APPROVED'
-    detailStore[id] = { ...detailStore[id], status: 'APPROVED' }
-    return HttpResponse.json({
-      message: '지원이 승인되었습니다.',
-      status: 'APPROVED',
-    })
-  }),
+  ),
 
   // 거절
-  http.post('/api/v1/applications/:applicationId/reject', ({ params }) => {
-    const id = Number(params.applicationId)
-    const t = listStore.find((a) => a.application_id === id)
-    if (!t || !detailStore[id]) {
-      return HttpResponse.json({ detail: '찾을 수 없습니다.' }, { status: 404 })
+  http.post(
+    'https://ozcoding.site/api/v1/applications/:applicationId/reject',
+    ({ params }) => {
+      const id = Number(params.applicationId)
+      const t = listStore.find((a) => a.application_id === id)
+      if (!t || !detailStore[id]) {
+        return HttpResponse.json(
+          { detail: '찾을 수 없습니다.' },
+          { status: 404 }
+        )
+      }
+      t.status = 'REJECTED'
+      detailStore[id] = { ...detailStore[id], status: 'REJECTED' }
+      return HttpResponse.json({
+        message: '지원이 거절되었습니다.',
+        status: 'REJECTED',
+      })
     }
-    t.status = 'REJECTED'
-    detailStore[id] = { ...detailStore[id], status: 'REJECTED' }
-    return HttpResponse.json({
-      message: '지원이 거절되었습니다.',
-      status: 'REJECTED',
-    })
-  }),
+  ),
+]
+
+//지원서 제출 핸들러
+export const applicationSubmitHandlers = [
+  http.post(
+    'https://ozcoding.site/api/v1/recruitments/:recruitmentId/applications',
+    async () => {
+      return HttpResponse.json({
+        application_id: 1000,
+        message: '스터디 공고 참여 신청 성공',
+      })
+    }
+  ),
 ]

--- a/src/mock/handlers/index.ts
+++ b/src/mock/handlers/index.ts
@@ -3,7 +3,7 @@ import { tagHandlers } from './tags'
 import { chatHandlers } from './chatHandlers'
 import { recruitManageHandlers } from '../recruitManageHandlers'
 import { recruitmentEditHandlers } from '../recruitmentEditHandlers'
-import { applicationHandlers } from './applications'
+import { applicationHandlers, applicationSubmitHandlers } from './applications'
 
 export const handlers = [
   ...notificationHandlers,
@@ -12,4 +12,5 @@ export const handlers = [
   ...recruitManageHandlers,
   ...recruitmentEditHandlers,
   ...applicationHandlers,
+  ...applicationSubmitHandlers,
 ]

--- a/src/mock/handlers/tags.ts
+++ b/src/mock/handlers/tags.ts
@@ -65,7 +65,7 @@ const paginate = <T>(arr: T[], page: number, size: number) => {
 
 // 검색 + 페이지네이션
 export const tagHandlers = [
-  http.get('/api/v1/recruitments/tags', ({ request }) => {
+  http.get('https://ozcoding.site/api/v1/recruitments/tags', ({ request }) => {
     const url = new URL(request.url)
     const search = (url.searchParams.get('search') || '').trim().toLowerCase()
     const page = parseInt(url.searchParams.get('page') || '1', 10)
@@ -82,25 +82,31 @@ export const tagHandlers = [
   }),
 
   // 새 태그 등록 (중복시 409)
-  http.post('/api/v1/recruitments/tags', async ({ request }) => {
-    const body = await request.json().catch(() => ({}) as any)
-    const name = (body?.name ?? '').trim()
-    if (!name) {
-      return HttpResponse.json({ detail: 'name is required' }, { status: 400 })
-    }
+  http.post(
+    'https://ozcoding.site/api/v1/recruitments/tags',
+    async ({ request }) => {
+      const body = await request.json().catch(() => ({}) as any)
+      const name = (body?.name ?? '').trim()
+      if (!name) {
+        return HttpResponse.json(
+          { detail: 'name is required' },
+          { status: 400 }
+        )
+      }
 
-    const exists = tagsDb.some(
-      (t) => t.name.toLowerCase() === name.toLowerCase()
-    )
-    if (exists) {
-      return HttpResponse.json(
-        { detail: 'Tag already exists' },
-        { status: 409 }
+      const exists = tagsDb.some(
+        (t) => t.name.toLowerCase() === name.toLowerCase()
       )
-    }
+      if (exists) {
+        return HttpResponse.json(
+          { detail: 'Tag already exists' },
+          { status: 409 }
+        )
+      }
 
-    const tag: Tag = { id: ++seq, name }
-    tagsDb.unshift(tag) // 최신 우선
-    return HttpResponse.json(tag, { status: 201 })
-  }),
+      const tag: Tag = { id: ++seq, name }
+      tagsDb.unshift(tag) // 최신 우선
+      return HttpResponse.json(tag, { status: 201 })
+    }
+  ),
 ]

--- a/src/pages/test-page/TestModalPage.tsx
+++ b/src/pages/test-page/TestModalPage.tsx
@@ -19,6 +19,7 @@ export default function TestApplicationModalPage() {
         open={openApplication}
         onClose={() => setOpenApplication(false)}
         title="Unity 게임 개발 프로젝트 팀원 모집"
+        recruitmentUuid="1"
       />
     </div>
   )

--- a/src/types/applicant.ts
+++ b/src/types/applicant.ts
@@ -35,3 +35,18 @@ export interface ApplicationDetail {
   status: ApplicantStatus
   applied_at: string
 }
+
+// 제출 관련 타입 정의
+export interface SubmitApplicationPayload {
+  self_introduction: string
+  motivation: string
+  objective: string
+  available_time: string
+  has_study_experience: boolean
+  study_experience?: string
+}
+
+export interface SubmitApplicationResponse {
+  application_id: number
+  message: string
+}


### PR DESCRIPTION
## 📌 개요

- 스터디 지원서 제출 기능을 API와 연동

## 🔧 작업 내용

- [ ] submitApplication API 함수
- [ ] ApplicationModal에 API 연동 로직 추가
- [ ] 제출 성공 시 폼 리셋 및 모달 닫기 처리
- [ ] 제출 실패 시 에러 메시지 토스트 출력

## 📎 관련 이슈

closes #244 

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/a3be7324-1890-49bc-8590-0735b59e2b0d

## 💬 리뷰어 참고 사항

