### PR TITLE
feat: 헤더의 UserMenu 액션 구현(#252)

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -40,7 +40,7 @@ async function doRefresh(): Promise<string | null> {
   }
 }
 
-async function getOrCreateRefresh(): Promise<string | null> {
+export async function getOrCreateRefresh(): Promise<string | null> {
   if (!refreshPromise) {
     refreshPromise = doRefresh().finally(() => {
       refreshPromise = null

--- a/src/components/commons/header/components/user-section/AuthMenu.tsx
+++ b/src/components/commons/header/components/user-section/AuthMenu.tsx
@@ -1,5 +1,6 @@
 import PageLink from '@components/commons/page-link/PageLink'
-
+const ACCOUNT = 'https://account.ozcoding.site'
+const returnTo = encodeURIComponent(window.location.href)
 export default function AuthMenu() {
   return (
     <>
@@ -7,7 +8,7 @@ export default function AuthMenu() {
         pageLinkInnerText="로그인"
         variant="text"
         fontWeight="normal"
-        link="/login"
+        link={`${ACCOUNT}/auth/login?return_to=${returnTo}`}
         size="lg"
         className="p-0"
       />

--- a/src/components/commons/header/components/user-section/HeaderUserSection.tsx
+++ b/src/components/commons/header/components/user-section/HeaderUserSection.tsx
@@ -10,7 +10,16 @@ export default function HeaderUserSection() {
 
   const isLoggedIn = useAuth((state) => state.isLoggedIn())
   const userNickname = useAuth((state) => state.user?.nickname ?? '사용자')
-  console.log(userNickname) // joo
+  const bootstrapped = useAuth((state) => state.bootstrapped)
+
+  if (!bootstrapped) {
+    return (
+      <div className="flex items-center gap-4">
+        <div className="h-10 w-10 animate-pulse rounded-full bg-gray-200" />
+        <div className="h-6 w-20 animate-pulse rounded bg-gray-200" />
+      </div>
+    )
+  }
 
   return (
     <div className="flex items-center gap-4">

--- a/src/components/commons/header/components/user-section/UserMenu.tsx
+++ b/src/components/commons/header/components/user-section/UserMenu.tsx
@@ -5,6 +5,7 @@ import { cn } from '@utils/cn'
 import { UserRound as UserRoundIcon, LogOut as LogOutIcon } from 'lucide-react'
 import { useRef } from 'react'
 import { EXTERNAL } from '@src/constants/external'
+import { logoutHard } from '@src/store/auth'
 
 interface UserMenuProps {
   isNotificationOpen: boolean
@@ -32,6 +33,9 @@ export default function UserMenu({
     setIsUserMenuOpen(!isUserMenuOpen)
   }
 
+  const handleLogout = async () => {
+    await logoutHard()
+  }
   useOutsideClick(isUserMenuOpen, [userMenuButtonRef, userMenuPanelRef], () =>
     setIsUserMenuOpen(false)
   )
@@ -62,13 +66,13 @@ export default function UserMenu({
             <UserRoundIcon className="h-4 w-4" />
             마이페이지
           </a>
-          <a
-            href={EXTERNAL.ACCOUNT_ROOT}
+          <button
+            onClick={handleLogout}
             className="flex w-full items-center gap-3 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
           >
             <LogOutIcon className="h-4 w-4 rotate-180" />
             로그아웃
-          </a>
+          </button>
         </div>
       )}
     </div>

--- a/src/constants/apiendpoint.ts
+++ b/src/constants/apiendpoint.ts
@@ -2,7 +2,7 @@ export const API_END_POINTS = {
   // 유저 상태관리용 상수
   ME: 'api/v1/info/',
   REFRESH: 'api/v1/auth/refresh',
-  LOGOUT: '/auth/logout',
+  LOGOUT: 'api/v1/auth/logout',
 
   // 구인공고 관련 상수
   RECRUITMENTS_LIST: '/recruitments', // 구인 공고 목록 조회

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -6,7 +6,6 @@ export function useMediaQuery(query: string): boolean {
 
   useEffect(() => {
     const media = window.matchMedia(query)
-    console.log(media, media.matches)
 
     if (media.matches !== matches) {
       setMatches(media.matches)

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { goLogin } from '../utils/redirect'
 import { API_END_POINTS } from '@src/constants/apiendpoint'
-import { api, setAccessToken } from '@src/api/api'
+import { api, getOrCreateRefresh, setAccessToken } from '@src/api/api'
 
 export interface User {
   id: number
@@ -62,6 +62,10 @@ export const useAuth = create<AuthState>()(
         set({ loading: true }, false, 'auth/bootstrap:start')
 
         try {
+          // 1. 먼저 refresh token으로 access token 발급 시도
+          await getOrCreateRefresh()
+
+          // 2. access token이 있으면 사용자 정보 조회
           const me = await get().tryFetchMe()
           set(
             { user: me, bootstrapped: true, loading: false },


### PR DESCRIPTION
## 📌 개요
- 헤더의 UserMenu 액션 구현

## 🔧 작업 내용
- [ ] 헤더의 UserMenu 스켈레톤 생성
- [ ] 로그아웃 엔드포인트 수정
- [ ] 로그아웃 기능 삽입
- [ ] refresh token으로 access token 발급 시도했다가 access token이 있으면 사용자 정보 조회(재민님 코드 한줄 수정)

## 📎 관련 이슈

closes #252 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
